### PR TITLE
fix: ASC-26094 - padding bottom android

### DIFF
--- a/src/v4/PublicApi/Pages/AmityPostDetailPage/AmityPostDetailPage.tsx
+++ b/src/v4/PublicApi/Pages/AmityPostDetailPage/AmityPostDetailPage.tsx
@@ -538,10 +538,12 @@ const AmityPostDetailPage: FC<AmityPostDetailPageType> = ({ postId }) => {
           styles.scrollContainer,
           {
             paddingTop: topBarHeigh,
-            paddingBottom:
-              isKeyboardVisible && Platform.OS !== 'android'
-                ? keyboardHeight + footerHeight - topBarHeigh - bottom
-                : footerHeight - topBarHeigh,
+            paddingBottom: isKeyboardVisible
+              ? (Platform.OS !== 'android' ? keyboardHeight : 0) +
+                footerHeight -
+                topBarHeigh -
+                bottom
+              : footerHeight - topBarHeigh,
             height: adjustedHeight,
           },
         ]}


### PR DESCRIPTION
**Jira ticket :**

- https://ekoapp.atlassian.net/browse/ASC-26094

**Description :**
- When open the keyboard on android, we found the white space added on post detail. Because the height of the screen on android phone does not include the keyboard's height.
- Fixed by checking if the platform is android, then not use keyboard's height to calculate the padding

**Check lists :**

- [x] Test code
- [ ] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**


https://github.com/user-attachments/assets/f29dc4f6-8908-4dae-b5d8-ba4661bbb904



**Note (optional) :**
