### PR TITLE
Fix/sp 32565 fix nested navigation error

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ You can now import and use the following screens individually:
 
 - [`CommunityHome`](#)
 - [`PostDetail`](#)
+- [`UserProfile`](#)
 
 > ✅ Make sure your screen component is wrapped with `AmityPageRenderer` at the root level.
 >

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amity-react-native-social-ui-kit",
-  "version": "4.0.0-beta-30",
+  "version": "4.0.0-beta-31",
   "description": "Social UIKit",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,6 @@
 import { NativeModules, Platform } from 'react-native';
 import AmityUiKitProvider from './providers/amity-ui-kit-provider';
-import AmityUiKitSocial from './routes/SocialNavigator';
+import AmityUiKitSocial from './v4/routes/AmitySocialUIKitV4Navigator';
 import AmityPageRenderer from './v4/routes/AmityPageRenderer';
 import PostDetail from './v4/screen/PostDetail';
 import CommunityHome from './v4/screen/CommunityHome';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,135 +1,69 @@
-import { NativeModules, Platform } from 'react-native';
+
 import AmityUiKitProvider from './providers/amity-ui-kit-provider';
 import AmityUiKitSocial from './v4/routes/AmitySocialUIKitV4Navigator';
 import AmityPageRenderer from './v4/routes/AmityPageRenderer';
 import PostDetail from './v4/screen/PostDetail';
 import CommunityHome from './v4/screen/CommunityHome';
-import {
-  AmityStoryTabComponent,
-  AmityCreateStoryPage,
-  AmityDraftStoryPage,
-  AmityViewStoryPage,
-  AmitySocialHomePage,
-  AmitySocialHomeTopNavigationComponent,
-  AmityCommunitySearchResultComponent,
-  AmitySocialGlobalSearchPage,
-  AmityTopSearchBarComponent,
-  AmityEmptyNewsFeedComponent,
-  AmityGlobalFeedComponent,
-  AmityMyCommunitiesComponent,
-  AmityNewsFeedComponent,
-  AmityPostContentComponent,
-  AmityPostDetailPage,
-  AmityPostTargetSelectionPageType,
-  AmityCreatePostMenuComponent,
-  AmityDetailedMediaAttachmentComponent,
-  AmityMediaAttachmentComponent,
-  AmityPostCommentComponent,
-  AmityPostComposerPage,
-  AmityPostEngagementActionsComponent,
-  AmityPostTargetSelectionPage,
-  AmityReactionListComponent,
-  AmityStoryTargetSelectionPage,
-  AmityUserSearchResultComponent,
-  AmityMyCommunitiesSearchPage,
-  AmityExploreComponent,
-  AmityAllCategoriesPage,
-  AmityCommunitiesByCategoryPage,
-  AmityCommunityProfilePage,
-  AmityCreateLivestreamPage,
-  AmityLivestreamPostTargetSelectionPage,
-  AmityLivestreamTerminatedPage,
-  AmityLivestreamPlayerPage,
-  AmityPollTargetSelectionPage,
-  AmityPollPostComposerPage,
-  AmityCommunityFeedComponent,
-  AmityCommunityHeaderComponent,
-  AmityCommunityImageFeedComponent,
-  AmityCommunityVideoFeedComponent,
-  AmityThumbnailActionComponent,
-  AmityUserProfilePage,
-  AmityPostEngagementContentComponent,
-  AmityPostTargetType,
-} from './v4';
+import UserProfile from  './v4/screen/UserProfile'
+// import {
+//   AmityStoryTabComponent,
+//   AmityCreateStoryPage,
+//   AmityDraftStoryPage,
+//   AmityViewStoryPage,
+//   AmitySocialHomePage,
+//   AmitySocialHomeTopNavigationComponent,
+//   AmityCommunitySearchResultComponent,
+//   AmitySocialGlobalSearchPage,
+//   AmityTopSearchBarComponent,
+//   AmityEmptyNewsFeedComponent,
+//   AmityGlobalFeedComponent,
+//   AmityMyCommunitiesComponent,
+//   AmityNewsFeedComponent,
+//   AmityPostContentComponent,
+//   AmityPostDetailPage,
+//   AmityPostTargetSelectionPageType,
+//   AmityCreatePostMenuComponent,
+//   AmityDetailedMediaAttachmentComponent,
+//   AmityMediaAttachmentComponent,
+//   AmityPostCommentComponent,
+//   AmityPostComposerPage,
+//   AmityPostEngagementActionsComponent,
+//   AmityPostTargetSelectionPage,
+//   AmityReactionListComponent,
+//   AmityStoryTargetSelectionPage,
+//   AmityUserSearchResultComponent,
+//   AmityMyCommunitiesSearchPage,
+//   AmityExploreComponent,
+//   AmityAllCategoriesPage,
+//   AmityCommunitiesByCategoryPage,
+//   AmityCommunityProfilePage,
+//   AmityCreateLivestreamPage,
+//   AmityLivestreamPostTargetSelectionPage,
+//   AmityLivestreamTerminatedPage,
+//   AmityLivestreamPlayerPage,
+//   AmityPollTargetSelectionPage,
+//   AmityPollPostComposerPage,
+//   AmityCommunityFeedComponent,
+//   AmityCommunityHeaderComponent,
+//   AmityCommunityImageFeedComponent,
+//   AmityCommunityVideoFeedComponent,
+//   AmityThumbnailActionComponent,
+//   AmityUserProfilePage,
+//   AmityPostEngagementContentComponent,
+//   AmityPostTargetType,
+// } from './v4';
 
-import {
-  AmityStoryTabComponentEnum,
-  AmityPostComposerMode,
-  mediaAttachment,
-} from './v4/PublicApi/types';
+// import {
+//   AmityStoryTabComponentEnum,
+//   AmityPostComposerMode,
+//   mediaAttachment,
+// } from './v4/PublicApi/types';
 
-const LINKING_ERROR =
-  `The package 'amity-react-native-social-ui-kit' doesn't seem to be linked. Make sure: \n\n` +
-  Platform.select({ ios: "- You have run 'pod install'\n", default: '' }) +
-  '- You rebuilt the app after installing the package\n' +
-  '- You are not using Expo Go\n';
-
-const AmityReactNativeSocialUiKit = NativeModules.AmityReactNativeSocialUiKit
-  ? NativeModules.AmityReactNativeSocialUiKit
-  : new Proxy(
-      {},
-      {
-        get() {
-          throw new Error(LINKING_ERROR);
-        },
-      }
-    );
-
-export function multiply(a: number, b: number): Promise<number> {
-  return AmityReactNativeSocialUiKit.multiply(a, b + 2 + 3);
-}
 export {
   AmityUiKitProvider,
   AmityUiKitSocial,
-  AmityStoryTabComponent,
-  AmityStoryTabComponentEnum,
-  AmityCreateStoryPage,
-  AmityDraftStoryPage,
-  AmityViewStoryPage,
-  AmitySocialHomePage,
-  AmitySocialHomeTopNavigationComponent,
-  AmityCommunitySearchResultComponent,
-  AmitySocialGlobalSearchPage,
-  AmityTopSearchBarComponent,
-  AmityEmptyNewsFeedComponent,
-  AmityGlobalFeedComponent,
-  AmityMyCommunitiesComponent,
-  AmityNewsFeedComponent,
-  AmityPostContentComponent,
-  AmityPostDetailPage,
-  AmityPostTargetSelectionPageType,
-  AmityCreatePostMenuComponent,
-  AmityDetailedMediaAttachmentComponent,
-  AmityMediaAttachmentComponent,
-  AmityPostCommentComponent,
-  AmityPostComposerPage,
-  AmityPostEngagementActionsComponent,
-  AmityPostTargetSelectionPage,
-  AmityReactionListComponent,
-  AmityStoryTargetSelectionPage,
-  AmityUserSearchResultComponent,
-  AmityMyCommunitiesSearchPage,
-  AmityPostComposerMode,
-  mediaAttachment,
-  AmityExploreComponent,
   AmityPageRenderer,
   PostDetail,
   CommunityHome,
-  AmityAllCategoriesPage,
-  AmityCommunitiesByCategoryPage,
-  AmityCommunityProfilePage,
-  AmityCreateLivestreamPage,
-  AmityLivestreamPostTargetSelectionPage,
-  AmityLivestreamTerminatedPage,
-  AmityLivestreamPlayerPage,
-  AmityPollTargetSelectionPage,
-  AmityPollPostComposerPage,
-  AmityCommunityFeedComponent,
-  AmityCommunityHeaderComponent,
-  AmityCommunityImageFeedComponent,
-  AmityCommunityVideoFeedComponent,
-  AmityThumbnailActionComponent,
-  AmityUserProfilePage,
-  AmityPostEngagementContentComponent,
-  AmityPostTargetType,
+  UserProfile
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,69 +1,135 @@
-
+import { NativeModules, Platform } from 'react-native';
 import AmityUiKitProvider from './providers/amity-ui-kit-provider';
 import AmityUiKitSocial from './v4/routes/AmitySocialUIKitV4Navigator';
 import AmityPageRenderer from './v4/routes/AmityPageRenderer';
 import PostDetail from './v4/screen/PostDetail';
 import CommunityHome from './v4/screen/CommunityHome';
-import UserProfile from  './v4/screen/UserProfile'
-// import {
-//   AmityStoryTabComponent,
-//   AmityCreateStoryPage,
-//   AmityDraftStoryPage,
-//   AmityViewStoryPage,
-//   AmitySocialHomePage,
-//   AmitySocialHomeTopNavigationComponent,
-//   AmityCommunitySearchResultComponent,
-//   AmitySocialGlobalSearchPage,
-//   AmityTopSearchBarComponent,
-//   AmityEmptyNewsFeedComponent,
-//   AmityGlobalFeedComponent,
-//   AmityMyCommunitiesComponent,
-//   AmityNewsFeedComponent,
-//   AmityPostContentComponent,
-//   AmityPostDetailPage,
-//   AmityPostTargetSelectionPageType,
-//   AmityCreatePostMenuComponent,
-//   AmityDetailedMediaAttachmentComponent,
-//   AmityMediaAttachmentComponent,
-//   AmityPostCommentComponent,
-//   AmityPostComposerPage,
-//   AmityPostEngagementActionsComponent,
-//   AmityPostTargetSelectionPage,
-//   AmityReactionListComponent,
-//   AmityStoryTargetSelectionPage,
-//   AmityUserSearchResultComponent,
-//   AmityMyCommunitiesSearchPage,
-//   AmityExploreComponent,
-//   AmityAllCategoriesPage,
-//   AmityCommunitiesByCategoryPage,
-//   AmityCommunityProfilePage,
-//   AmityCreateLivestreamPage,
-//   AmityLivestreamPostTargetSelectionPage,
-//   AmityLivestreamTerminatedPage,
-//   AmityLivestreamPlayerPage,
-//   AmityPollTargetSelectionPage,
-//   AmityPollPostComposerPage,
-//   AmityCommunityFeedComponent,
-//   AmityCommunityHeaderComponent,
-//   AmityCommunityImageFeedComponent,
-//   AmityCommunityVideoFeedComponent,
-//   AmityThumbnailActionComponent,
-//   AmityUserProfilePage,
-//   AmityPostEngagementContentComponent,
-//   AmityPostTargetType,
-// } from './v4';
+import {
+  AmityStoryTabComponent,
+  AmityCreateStoryPage,
+  AmityDraftStoryPage,
+  AmityViewStoryPage,
+  AmitySocialHomePage,
+  AmitySocialHomeTopNavigationComponent,
+  AmityCommunitySearchResultComponent,
+  AmitySocialGlobalSearchPage,
+  AmityTopSearchBarComponent,
+  AmityEmptyNewsFeedComponent,
+  AmityGlobalFeedComponent,
+  AmityMyCommunitiesComponent,
+  AmityNewsFeedComponent,
+  AmityPostContentComponent,
+  AmityPostDetailPage,
+  AmityPostTargetSelectionPageType,
+  AmityCreatePostMenuComponent,
+  AmityDetailedMediaAttachmentComponent,
+  AmityMediaAttachmentComponent,
+  AmityPostCommentComponent,
+  AmityPostComposerPage,
+  AmityPostEngagementActionsComponent,
+  AmityPostTargetSelectionPage,
+  AmityReactionListComponent,
+  AmityStoryTargetSelectionPage,
+  AmityUserSearchResultComponent,
+  AmityMyCommunitiesSearchPage,
+  AmityExploreComponent,
+  AmityAllCategoriesPage,
+  AmityCommunitiesByCategoryPage,
+  AmityCommunityProfilePage,
+  AmityCreateLivestreamPage,
+  AmityLivestreamPostTargetSelectionPage,
+  AmityLivestreamTerminatedPage,
+  AmityLivestreamPlayerPage,
+  AmityPollTargetSelectionPage,
+  AmityPollPostComposerPage,
+  AmityCommunityFeedComponent,
+  AmityCommunityHeaderComponent,
+  AmityCommunityImageFeedComponent,
+  AmityCommunityVideoFeedComponent,
+  AmityThumbnailActionComponent,
+  AmityUserProfilePage,
+  AmityPostEngagementContentComponent,
+  AmityPostTargetType,
+} from './v4';
 
-// import {
-//   AmityStoryTabComponentEnum,
-//   AmityPostComposerMode,
-//   mediaAttachment,
-// } from './v4/PublicApi/types';
+import {
+  AmityStoryTabComponentEnum,
+  AmityPostComposerMode,
+  mediaAttachment,
+} from './v4/PublicApi/types';
 
+const LINKING_ERROR =
+  `The package 'amity-react-native-social-ui-kit' doesn't seem to be linked. Make sure: \n\n` +
+  Platform.select({ ios: "- You have run 'pod install'\n", default: '' }) +
+  '- You rebuilt the app after installing the package\n' +
+  '- You are not using Expo Go\n';
+
+const AmityReactNativeSocialUiKit = NativeModules.AmityReactNativeSocialUiKit
+  ? NativeModules.AmityReactNativeSocialUiKit
+  : new Proxy(
+      {},
+      {
+        get() {
+          throw new Error(LINKING_ERROR);
+        },
+      }
+    );
+
+export function multiply(a: number, b: number): Promise<number> {
+  return AmityReactNativeSocialUiKit.multiply(a, b + 2 + 3);
+}
 export {
   AmityUiKitProvider,
   AmityUiKitSocial,
+  AmityStoryTabComponent,
+  AmityStoryTabComponentEnum,
+  AmityCreateStoryPage,
+  AmityDraftStoryPage,
+  AmityViewStoryPage,
+  AmitySocialHomePage,
+  AmitySocialHomeTopNavigationComponent,
+  AmityCommunitySearchResultComponent,
+  AmitySocialGlobalSearchPage,
+  AmityTopSearchBarComponent,
+  AmityEmptyNewsFeedComponent,
+  AmityGlobalFeedComponent,
+  AmityMyCommunitiesComponent,
+  AmityNewsFeedComponent,
+  AmityPostContentComponent,
+  AmityPostDetailPage,
+  AmityPostTargetSelectionPageType,
+  AmityCreatePostMenuComponent,
+  AmityDetailedMediaAttachmentComponent,
+  AmityMediaAttachmentComponent,
+  AmityPostCommentComponent,
+  AmityPostComposerPage,
+  AmityPostEngagementActionsComponent,
+  AmityPostTargetSelectionPage,
+  AmityReactionListComponent,
+  AmityStoryTargetSelectionPage,
+  AmityUserSearchResultComponent,
+  AmityMyCommunitiesSearchPage,
+  AmityPostComposerMode,
+  mediaAttachment,
+  AmityExploreComponent,
   AmityPageRenderer,
   PostDetail,
   CommunityHome,
-  UserProfile
+  AmityAllCategoriesPage,
+  AmityCommunitiesByCategoryPage,
+  AmityCommunityProfilePage,
+  AmityCreateLivestreamPage,
+  AmityLivestreamPostTargetSelectionPage,
+  AmityLivestreamTerminatedPage,
+  AmityLivestreamPlayerPage,
+  AmityPollTargetSelectionPage,
+  AmityPollPostComposerPage,
+  AmityCommunityFeedComponent,
+  AmityCommunityHeaderComponent,
+  AmityCommunityImageFeedComponent,
+  AmityCommunityVideoFeedComponent,
+  AmityThumbnailActionComponent,
+  AmityUserProfilePage,
+  AmityPostEngagementContentComponent,
+  AmityPostTargetType,
 };

--- a/src/v4/PublicApi/Components/AmityCommunityHeaderComponent/AmityCommunityHeaderComponent.tsx
+++ b/src/v4/PublicApi/Components/AmityCommunityHeaderComponent/AmityCommunityHeaderComponent.tsx
@@ -35,6 +35,7 @@ type AmityCommunityHeaderComponentProps = {
   isScrolled?: boolean;
   isScrolling?: boolean;
   onHeightChange?: (height: number) => void;
+  isFromComponent?: boolean;
 };
 
 const AmityCommunityHeaderComponent: FC<AmityCommunityHeaderComponentProps> = ({
@@ -43,6 +44,7 @@ const AmityCommunityHeaderComponent: FC<AmityCommunityHeaderComponentProps> = ({
   isScrolling = false,
   isScrolled,
   onHeightChange,
+  isFromComponent
 }) => {
   const client = Client.getActiveClient();
   const navigation =
@@ -95,6 +97,7 @@ const AmityCommunityHeaderComponent: FC<AmityCommunityHeaderComponentProps> = ({
             community={community}
             smallHeader={true}
             hideButtons={!isScrolled && isScrolling}
+            isFromComponent={isFromComponent}
           />
         </View>
       ) : (
@@ -113,6 +116,7 @@ const AmityCommunityHeaderComponent: FC<AmityCommunityHeaderComponentProps> = ({
             community={community}
             smallHeader={false}
             hideButtons={isScrolling}
+            isFromComponent={isFromComponent}
           />
           <View style={styles.communityNameWrap}>
             {!community.isPublic && (

--- a/src/v4/PublicApi/Pages/AmityCommunityProfilePage/AmityCommunityProfilePage.tsx
+++ b/src/v4/PublicApi/Pages/AmityCommunityProfilePage/AmityCommunityProfilePage.tsx
@@ -32,26 +32,31 @@ import AmityCommunityVideoFeedComponent from '../../Components/AmityCommunityVid
 import CommunityCoverNavigator from '../../../elements/CommunityCover/CommunityCoverNavigator';
 import {
   NativeStackNavigationProp,
-  NativeStackScreenProps,
 } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../../../routes/RouteParamList';
 import CommunityCreatePostButton from '../../../elements/CommunityCreatePostButton/CommunityCreatePostButton';
 import { SvgXml } from 'react-native-svg';
 import { useBehaviour } from '../../../../v4/providers/BehaviourProvider';
-import { useNavigation } from '@react-navigation/native';
+import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
 import { livestream, poll, post, story } from '../../../../v4/assets/icons';
 import { useTheme } from 'react-native-paper';
 import { MyMD3Theme } from '../../../../providers/amity-ui-kit-provider';
 
-const AmityCommunityProfilePage = ({
-  route,
-}: NativeStackScreenProps<RootStackParamList, 'CommunityProfilePage'>) => {
+type ICommunityProfilePage = {
+  defaultCommunityId?: string;
+};
+const AmityCommunityProfilePage: React.FC<ICommunityProfilePage> = ({
+  defaultCommunityId
+}) => {
   const pageId = PageID.community_profile_page;
-  const { communityId } = route.params;
+
   const { accessibilityId, themeStyles } = useAmityPage({
     pageId,
   });
-
+  const route = useRoute<RouteProp<RootStackParamList, 'CommunityProfilePage'>>();
+  const routeCommunityId = route?.params?.communityId;
+  const navigation = useNavigation<NativeStackNavigationProp<any>>();
+  const [communityId, setCommunityId] = useState<string>()
   const [currentTab, setCurrentTab] = useState(
     CommunityProfileTab.community_feed
   );
@@ -67,6 +72,17 @@ const AmityCommunityProfilePage = ({
   const feedRef = useRef<AmityCommunityFeedRef>(null);
 
   const styles = useStyles(themeStyles);
+
+  useEffect(() => {
+    const routes = navigation.getState().routes;
+    if (defaultCommunityId && routes.length === 1) {
+      setCommunityId(defaultCommunityId);
+    } else if (routeCommunityId) {
+      setCommunityId(routeCommunityId);
+    }
+    return () => { setCommunityId(undefined); }
+  }, [defaultCommunityId, routeCommunityId]);
+
 
   useEffect(() => {
     if (isScrolledPastHeader) {
@@ -176,6 +192,7 @@ const AmityCommunityProfilePage = ({
             pageId={pageId}
             componentId={ComponentID.community_header}
             communityId={communityId}
+            isFromComponent={!!defaultCommunityId}
           />
         </View>
       )}
@@ -194,6 +211,7 @@ const AmityCommunityProfilePage = ({
             communityId={communityId}
             isScrolled={true}
             isScrolling={isScrolling}
+            isFromComponent={!!defaultCommunityId}
           />
           <View style={styles.smallHeaderCommunityTabWrap}>
             {renderCommunityProfileTab()}
@@ -218,6 +236,7 @@ const AmityCommunityProfilePage = ({
           communityId={communityId}
           onHeightChange={setHeaderHeight}
           isScrolling={isScrolling}
+          isFromComponent={!!defaultCommunityId}
         />
         {renderCommunityProfileTab()}
         {renderTabComponent()}

--- a/src/v4/PublicApi/Pages/AmityPostDetailPage/AmityPostDetailPage.tsx
+++ b/src/v4/PublicApi/Pages/AmityPostDetailPage/AmityPostDetailPage.tsx
@@ -185,7 +185,7 @@ const AmityPostDetailPage: FC<AmityPostDetailPageType> = ({
   const onPressBack = useCallback(() => {
     const routes = navigation.getState().routes;
     if (isFromComponent && routes.length === 1) {
-      navigation.navigate('Home');
+      navigation.navigate('AmitySocialHomePage');
     } else {
       if (routes[routes.length - 2]?.name === 'CreateLivestream')
         return navigation.pop(3);

--- a/src/v4/PublicApi/Pages/AmityPostDetailPage/AmityPostDetailPage.tsx
+++ b/src/v4/PublicApi/Pages/AmityPostDetailPage/AmityPostDetailPage.tsx
@@ -23,7 +23,7 @@ import { ComponentID, PageID } from '../../../enum/';
 import { TSearchItem, useAmityPage } from '../../../hook';
 import { useStyles } from './styles';
 import BackButtonIconElement from '../../Elements/BackButtonIconElement/BackButtonIconElement';
-import { useNavigation } from '@react-navigation/native';
+import { CommonActions, useNavigation } from '@react-navigation/native';
 import { RootStackParamList } from '../../../routes/RouteParamList';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import {
@@ -143,7 +143,7 @@ const AmityPostDetailPage: FC<AmityPostDetailPageType> = ({
   }, []);
 
   useLayoutEffect(() => {
-    if (!postId) return () => {};
+    if (!postId) return () => { };
     setLoading(true);
     let unsub: () => void;
     let hasSubscribed = false;
@@ -186,6 +186,12 @@ const AmityPostDetailPage: FC<AmityPostDetailPageType> = ({
     const routes = navigation.getState().routes;
     if (isFromComponent && routes.length === 1) {
       navigation.navigate('AmitySocialHomePage');
+      navigation.dispatch(
+        CommonActions.reset({
+          index: 0,
+          routes: [{ name: 'AmitySocialHomePage' }],
+        })
+      );
     } else {
       if (routes[routes.length - 2]?.name === 'CreateLivestream')
         return navigation.pop(3);
@@ -359,9 +365,9 @@ const AmityPostDetailPage: FC<AmityPostDetailPageType> = ({
             paddingTop: topBarHeigh,
             paddingBottom: isKeyboardVisible
               ? (Platform.OS !== 'android' ? keyboardHeight : 0) +
-                footerHeight -
-                topBarHeigh -
-                bottom
+              footerHeight -
+              topBarHeigh -
+              bottom
               : footerHeight - topBarHeigh,
             height: adjustedHeight,
           },

--- a/src/v4/PublicApi/Pages/AmityUserProfilePage/AmityUserProfilePage.tsx
+++ b/src/v4/PublicApi/Pages/AmityUserProfilePage/AmityUserProfilePage.tsx
@@ -15,6 +15,7 @@ import {
   type NativeScrollEvent,
   ScrollView,
   Pressable,
+  SafeAreaView,
 } from 'react-native';
 import { useStyles } from './styles';
 import {
@@ -329,7 +330,7 @@ function UserProfile({ userId }: UserProfilePageProps) {
     if (isMyProfile || isAccepted) navigation.navigate('FollowerList', user);
   }, [isAccepted, isMyProfile, navigation, user]);
   return (
-    <View style={styles.container}>
+    <SafeAreaView style={styles.container}>
       <ScrollView
         style={{ flex: 1 }}
         ref={scrollViewRef}
@@ -377,7 +378,7 @@ function UserProfile({ userId }: UserProfilePageProps) {
       {(client as Amity.Client).userId === userId && (
         <FloatingButton onPress={handleOnPressPostBtn} isGlobalFeed={false} />
       )}
-    </View>
+    </SafeAreaView>
   );
 }
 

--- a/src/v4/PublicApi/Pages/AmityUserProfilePage/AmityUserProfilePage.tsx
+++ b/src/v4/PublicApi/Pages/AmityUserProfilePage/AmityUserProfilePage.tsx
@@ -27,7 +27,7 @@ import {
 import Feed from '../../../screen/Feed';
 import CustomTab from '../../../../components/CustomTab';
 import type { FeedRefType } from '../../../screen/CommunityHome';
-import { useNavigation } from '@react-navigation/native';
+import { CommonActions, useFocusEffect, useNavigation, } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import useAuth from '../../../../hooks/useAuth';
 import { SvgXml } from 'react-native-svg';
@@ -48,12 +48,18 @@ import GalleryComponent from '../../../component/Gallery/GalleryComponent';
 import { useFile } from '../../../hook';
 import { defaultAvatarUri } from '../../../assets';
 import { ImageSizeState } from '../../../enum';
-import { RootStackParamList } from '~/v4/routes/RouteParamList';
+
 import { useUIKitDispatch } from '../../../../redux/store';
+import BackButton from '../../../../components/BackButton';
 
-type UserProfilePageProps = RootStackParamList['UserProfile'];
+type UserProfilePageProps = {
+  userId: string;
+  isFromComponent?: boolean;
+  isShowBackButton?: boolean;
+};
 
-function UserProfile({ userId }: UserProfilePageProps) {
+function UserProfile({ userId, isFromComponent, isShowBackButton }: UserProfilePageProps) {
+
   const theme = useTheme() as MyMD3Theme;
   const styles = useStyles();
   const { client } = useAuth();
@@ -104,6 +110,21 @@ function UserProfile({ userId }: UserProfilePageProps) {
     await UserRepository.Relationship.unBlockUser(userId);
     setFollowStatus('none');
   };
+  const handleGoBack = () => {
+    const routes = navigation.getState().routes;
+    if (isFromComponent && routes.length === 1) {
+      navigation.navigate('AmitySocialHomePage');
+      navigation.dispatch(
+        CommonActions.reset({
+          index: 0,
+          routes: [{ name: 'AmitySocialHomePage' }],
+        })
+      );
+    } else {
+      navigation.goBack();
+    }
+  }
+
   useLayoutEffect(() => {
     navigation.setOptions({
       // eslint-disable-next-line react/no-unstable-nested-components
@@ -122,8 +143,14 @@ function UserProfile({ userId }: UserProfilePageProps) {
           />
         </TouchableOpacity>
       ),
+      headerLeft: () => {
+        return isShowBackButton ? <BackButton onPress={handleGoBack} /> : null;
+      } 
+
     });
   }, [followStatus, navigation, styles.dotIcon, user]);
+
+
 
   useEffect(() => {
     (async () => {
@@ -147,12 +174,13 @@ function UserProfile({ userId }: UserProfilePageProps) {
     })();
   }, [getImage, user?.avatarFileId]);
 
-  useEffect(() => {
-    let userUnsubscribe: () => void;
-    let userRsUnsubscribe: () => void;
-    const unsubFollowing = subscribeTopic(getMyFollowingsTopic());
-    const unsubFollower = subscribeTopic(getMyFollowersTopic());
-    const unsubscribe = navigation.addListener('focus', () => {
+  useFocusEffect(
+    useCallback(() => {
+      let userUnsubscribe: () => void;
+      let userRsUnsubscribe: () => void;
+      const unsubFollowing = subscribeTopic(getMyFollowingsTopic());
+      const unsubFollower = subscribeTopic(getMyFollowersTopic());
+
       userRsUnsubscribe = UserRepository.Relationship.getFollowInfo(
         userId,
         (value) => {
@@ -161,27 +189,25 @@ function UserProfile({ userId }: UserProfilePageProps) {
             setFollowStatus(value.data.status);
             setFollowerCount(value.data.followerCount);
             setFollowingCount(value.data.followingCount);
-          } else {
           }
         }
       );
 
       userUnsubscribe = UserRepository.getUser(userId, ({ data, loading }) => {
-        if (!loading) {
+        if (!loading && data) {
           setUser(data);
-        } else {
         }
       });
-    });
 
-    return () => {
-      unsubscribe();
-      userUnsubscribe && userUnsubscribe();
-      userRsUnsubscribe && userRsUnsubscribe();
-      unsubFollowing();
-      unsubFollower();
-    };
-  }, [navigation, userId]);
+      return () => {
+        userUnsubscribe && userUnsubscribe();
+        userRsUnsubscribe && userRsUnsubscribe();
+        unsubFollowing();
+        unsubFollower();
+      };
+    }, [userId])
+  );
+
   const editProfileButton = () => {
     return (
       <TouchableOpacity
@@ -332,7 +358,7 @@ function UserProfile({ userId }: UserProfilePageProps) {
   return (
     <SafeAreaView style={styles.container}>
       <ScrollView
-        style={{ flex: 1 }}
+        style={{ flex: 1, backgroundColor: theme.colors.baseShade4 }}
         ref={scrollViewRef}
         onScroll={handleScroll}
         scrollEventThrottle={20}

--- a/src/v4/elements/CommunityCover/CommunityCover.tsx
+++ b/src/v4/elements/CommunityCover/CommunityCover.tsx
@@ -12,6 +12,7 @@ type CommunityCoverProps = {
   community: Amity.Community;
   smallHeader?: boolean;
   hideButtons?: boolean;
+  isFromComponent?: boolean;
 };
 
 const CommunityCover: FC<CommunityCoverProps> = ({
@@ -20,6 +21,7 @@ const CommunityCover: FC<CommunityCoverProps> = ({
   community,
   smallHeader = false,
   hideButtons = false,
+  isFromComponent
 }) => {
   const { apiRegion } = useAuth();
   const elementId = ElementID.community_cover;
@@ -77,6 +79,7 @@ const CommunityCover: FC<CommunityCoverProps> = ({
           pageId={pageId}
           componentId={componentId}
           communityId={community.communityId}
+          isFromComponent={isFromComponent}
         />
       )}
     </View>

--- a/src/v4/elements/CommunityCover/CommunityCoverNavigator.tsx
+++ b/src/v4/elements/CommunityCover/CommunityCoverNavigator.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react';
 import { Pressable, StyleSheet, View } from 'react-native';
 import BackButtonIconElement from '../../PublicApi/Elements/BackButtonIconElement/BackButtonIconElement';
-import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
+import { CommonActions, RouteProp, useNavigation, useRoute } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../../routes/RouteParamList';
 import { hexToRgba } from '../../../util/colorUtil';
@@ -13,20 +13,22 @@ type CommunityCoverNavigatorProps = {
   pageId?: PageID;
   componentId?: ComponentID;
   communityId: Amity.Community['communityId'];
+  isFromComponent?: boolean;
 };
 
 const CommunityCoverNavigator: FC<CommunityCoverNavigatorProps> = ({
   pageId = PageID.WildCardPage,
   componentId = ComponentID.WildCardComponent,
   communityId,
+  isFromComponent
 }) => {
+
   const { community } = useCommunity(communityId);
   const navigation =
     useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   const route =
     useRoute<RouteProp<RootStackParamList, 'CommunityProfilePage'>>();
   const { pop } = route?.params || {};
-
   const styles = StyleSheet.create({
     container: {
       position: 'absolute',
@@ -56,10 +58,22 @@ const CommunityCoverNavigator: FC<CommunityCoverNavigatorProps> = ({
       <Pressable
         style={styles.button}
         onPress={() => {
+          const routes = navigation.getState().routes;
           if (pop === 2) {
             return navigation.pop(2);
           }
-          navigation.goBack();
+          if (isFromComponent && routes.length === 1) {
+            navigation.navigate('AmitySocialHomePage');
+            navigation.dispatch(
+              CommonActions.reset({
+                index: 0,
+                routes: [{ name: 'AmitySocialHomePage' }],
+              })
+            );
+          } else {
+            navigation.goBack();
+          }
+
         }}
       >
         <BackButtonIconElement

--- a/src/v4/routes/AmityPageRenderer.tsx
+++ b/src/v4/routes/AmityPageRenderer.tsx
@@ -73,7 +73,7 @@ export default function PageRenderer({ children }: PageRendererProps) {
           <Stack.Navigator
             id={undefined}
             screenOptions={{
-              headerShown: false,
+
               headerShadowVisible: false,
               contentStyle: {
                 backgroundColor: 'white',
@@ -144,6 +144,7 @@ export default function PageRenderer({ children }: PageRendererProps) {
             <Stack.Screen
               name="CommunityProfilePage"
               children={() => <AmityCommunityProfilePage {...children.props} />}
+              options={{ headerShown: false }}
             />
             <Stack.Screen
               name="PendingPosts"
@@ -221,11 +222,10 @@ export default function PageRenderer({ children }: PageRendererProps) {
             />
             <Stack.Screen
               name="UserProfile"
-              component={UserProfile}
+              children={() => <UserProfile {...children.props} />}
               options={{
-                headerLeft: () => <BackButton />,
                 headerTitleAlign: 'center',
-                title: 'Member',
+                title: '',
               }}
             />
             <Stack.Screen name="EditProfile" component={EditProfile} />

--- a/src/v4/routes/AmityPageRenderer.tsx
+++ b/src/v4/routes/AmityPageRenderer.tsx
@@ -13,7 +13,6 @@ import useAuth from '../../hooks/useAuth';
 
 import CategoryList from '../../screens/CategorytList';
 import CommunityList from '../../screens/CommunityList';
-import CommunityHome from '../screen/CommunityHome';
 import { CommunitySetting } from '../../screens/CommunitySetting/index';
 import CommunityMemberDetail from '../../screens/CommunityMemberDetail/CommunityMemberDetail';
 import AmitySocialHomePage from '../PublicApi/Pages/AmitySocialHomePage/AmitySocialHomePage';
@@ -53,6 +52,10 @@ import EditPost from '../screen/EditPost/EditPost';
 import AmityExploreComponent from '../PublicApi/Components/AmityExploreComponent/AmityExploreComponent';
 import LivestreamPlayer from '../../screens/LivestreamPlayer';
 import PollPostComposer from '../screen/PollPostComposer';
+import AmityCommunityProfilePage from '../PublicApi/Pages/AmityCommunityProfilePage/AmityCommunityProfilePage';
+import LivestreamTerminated from '../screen/LivestreamTerminated';
+import PollTargetSelection from '../screen/PollTargetSelection';
+import LivestreamPostTargetSelection from '../screen/LivestreamPostTargetSelection';
 
 interface PageRendererProps {
   children: React.JSX.Element;
@@ -98,7 +101,7 @@ export default function PageRenderer({ children }: PageRendererProps) {
               options={{ headerShown: false }}
             />
             <Stack.Screen
-              name="Home"
+              name="AmitySocialHomePage"
               component={AmitySocialHomePage}
               options={{ headerShown: false }}
             />
@@ -134,13 +137,13 @@ export default function PageRenderer({ children }: PageRendererProps) {
             <Stack.Screen
               name="CategoryList"
               component={CategoryList}
-              options={({}) => ({
+              options={({ }) => ({
                 title: 'Category',
               })}
             />
             <Stack.Screen
-              name="CommunityHome"
-              children={() => <CommunityHome {...children.props} />}
+              name="CommunityProfilePage"
+              children={() => <AmityCommunityProfilePage {...children.props} />}
             />
             <Stack.Screen
               name="PendingPosts"
@@ -220,8 +223,9 @@ export default function PageRenderer({ children }: PageRendererProps) {
               name="UserProfile"
               component={UserProfile}
               options={{
-                title: '',
                 headerLeft: () => <BackButton />,
+                headerTitleAlign: 'center',
+                title: 'Member',
               }}
             />
             <Stack.Screen name="EditProfile" component={EditProfile} />
@@ -310,6 +314,19 @@ export default function PageRenderer({ children }: PageRendererProps) {
                 name="LivestreamPlayer"
                 component={LivestreamPlayer}
                 options={{ headerShown: false }}
+              />
+              <Stack.Screen
+                name="LivestreamTerminated"
+                component={LivestreamTerminated}
+                options={{ headerShown: false }}
+              />
+              <Stack.Screen
+                name="PollTargetSelection"
+                component={PollTargetSelection}
+              />
+              <Stack.Screen
+                name="LivestreamPostTargetSelection"
+                component={LivestreamPostTargetSelection}
               />
             </Stack.Group>
           </Stack.Navigator>

--- a/src/v4/routes/AmitySocialUIKitV4Navigator.tsx
+++ b/src/v4/routes/AmitySocialUIKitV4Navigator.tsx
@@ -82,7 +82,7 @@ export default function AmitySocialUIKitV4Navigator() {
             }}
           >
             <Stack.Screen
-              name="Home"
+              name="AmitySocialHomePage"
               component={AmitySocialHomePage}
               options={{ headerShown: false }}
             />

--- a/src/v4/routes/RouteParamList.tsx
+++ b/src/v4/routes/RouteParamList.tsx
@@ -5,7 +5,7 @@ import {
 import { AmityPostTargetSelectionPageType } from '../enum';
 
 export type RootStackParamList = {
-  Home: { postIdCallBack?: string };
+  AmitySocialHomePage: { postIdCallBack?: string };
   AmitySocialGlobalSearchPage: undefined;
   AmityMyCommunitiesSearchPage: undefined;
   CommunitySearch: undefined;

--- a/src/v4/screen/CommunityHome/index.tsx
+++ b/src/v4/screen/CommunityHome/index.tsx
@@ -103,7 +103,9 @@ export default function CommunityHome({
   const disposers: Amity.Unsubscriber[] = useMemo(() => [], []);
   const unsubCommunity = useRef(null);
 
+
   useEffect(() => {
+    
     if (communityIdParam) {
       setCommunityId(communityIdParam);
     } else if (defaultCommunityId && !communityIdParam) {
@@ -115,7 +117,7 @@ export default function CommunityHome({
   }, [communityIdParam, communityNameParam, defaultCommunityId]);
 
   const onClickBack = useCallback(() => {
-    const routes = navigation.getState().routes;
+      const routes = navigation.getState().routes;
     if (routes.length === 1) {
       navigation.navigate('Home');
       setCommunityName('');
@@ -293,8 +295,8 @@ export default function CommunityHome({
             <Text style={styles.pendingDescriptionText}>
               {isUserHasPermission
                 ? (pendingPosts.length > 30 && 'More than ') +
-                  pendingPosts.length +
-                  ' posts need approval'
+                pendingPosts.length +
+                ' posts need approval'
                 : 'Your posts are pending for review'}
             </Text>
           </View>
@@ -354,8 +356,8 @@ export default function CommunityHome({
             source={
               avatarUrl
                 ? {
-                    uri: avatarUrl,
-                  }
+                  uri: avatarUrl,
+                }
                 : require('../../assets/images/userAvatar.png')
             }
           />

--- a/src/v4/screen/PostDetail/index.tsx
+++ b/src/v4/screen/PostDetail/index.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import AmityPostDetailPage from '../../PublicApi/Pages/AmityPostDetailPage/AmityPostDetailPage';
-import { RouteProp, useRoute } from '@react-navigation/native';
+import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
 import { RootStackParamList } from '../../routes/RouteParamList';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
 type IPostDetailPage = {
   defaultPostId?: string;
@@ -9,13 +10,29 @@ type IPostDetailPage = {
 
 const PostDetail: React.FC<IPostDetailPage> = ({ defaultPostId }) => {
   const route = useRoute<RouteProp<RootStackParamList, 'PostDetail'>>();
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   const postIdFromRoute = route?.params?.postId;
+  const [postId, setPostId] = useState<string>('')
+  useEffect(() => {
+    const routes = navigation.getState().routes;
+
+    if (defaultPostId && routes.length === 1) {
+      setPostId(defaultPostId);
+    } else if (postIdFromRoute) {
+      setPostId(postIdFromRoute);
+    }
+
+    return () => {
+      setPostId('');
+    }
+  }, [])
+
 
   return (
     <AmityPostDetailPage
       showEndPopup={route?.params?.showEndPopup}
       isFromComponent={!!defaultPostId}
-      postId={defaultPostId || postIdFromRoute}
+      postId={postId}
     />
   );
 };

--- a/src/v4/screen/PostDetail/index.tsx
+++ b/src/v4/screen/PostDetail/index.tsx
@@ -31,7 +31,7 @@ const PostDetail: React.FC<IPostDetailPage> = ({ defaultPostId }) => {
   return (
     <AmityPostDetailPage
       showEndPopup={route?.params?.showEndPopup}
-      isFromComponent={!!defaultPostId}
+      isFromComponent={!!defaultPostId && !postIdFromRoute }
       postId={postId}
     />
   );

--- a/src/v4/screen/UserProfile/index.tsx
+++ b/src/v4/screen/UserProfile/index.tsx
@@ -1,19 +1,34 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import AmityUserProfilePage from '../../PublicApi/Pages/AmityUserProfilePage';
-import { RouteProp, useRoute } from '@react-navigation/native';
+import { RouteProp, useRoute, useNavigation } from '@react-navigation/native';
 import { RootStackParamList } from '../../routes/RouteParamList';
-import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
-type UserProfileProps = NativeStackScreenProps<
-  RootStackParamList,
-  'UserProfile'
->;
+type UserProfileProps = {
+  defaultUserId?: string;
+  isShowBackButton?: boolean;
+};
 
-function UserProfile(_: UserProfileProps) {
+function UserProfile({ defaultUserId, isShowBackButton }: UserProfileProps) {
   const route = useRoute<RouteProp<RootStackParamList, 'UserProfile'>>();
-  const userId = route?.params?.userId;
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+  const userIdFromRoute = route?.params?.userId;
+  const [userId, setUserId] = useState<string>('');
 
-  return <AmityUserProfilePage userId={userId} />;
+  useEffect(() => {
+    const routes = navigation.getState().routes;
+
+    if (defaultUserId && routes.length === 1) {
+      setUserId(defaultUserId);
+    } else if (userIdFromRoute) {
+      setUserId(userIdFromRoute);
+    }
+    return () => {
+      setUserId('');
+    }
+  }, []);
+
+  return <AmityUserProfilePage userId={userId} isFromComponent={!!defaultUserId && !userIdFromRoute} isShowBackButton={isShowBackButton ? isShowBackButton : !defaultUserId} />;
 }
 
 export default UserProfile;


### PR DESCRIPTION
**Jira ticket :**

**Description :**
- When calling AmitySocialUIKit, I use AmitySocialUIKitV4Navigator as default instead of AmitySocialUIKitNavigator so that we don't have 2 level of navigation container (I see we don't use any screens from AmitySocialUIKitNavigator, so changing to v4 navigator should be fine right? Need to double check with team)
- Add UserProfile component support
- Add readme doc regarding UserProfile component
- Fix community home page navigation issue when calling component  screens

**Check lists :**

- [ ] Test code
- [ ] Build local pass (optional)
- [ ] Code is the same level as origin/develop branch

**Screen shot :**

**Note (optional) :**
