### PR TITLE
fix: SP-32510 - edit community and edit post permission onBack navigation

### DIFF
--- a/src/v4/elements/CommunityCover/CommunityCoverNavigator.tsx
+++ b/src/v4/elements/CommunityCover/CommunityCoverNavigator.tsx
@@ -68,7 +68,7 @@ const CommunityCoverNavigator: FC<CommunityCoverNavigatorProps> = ({
       <Pressable
         style={styles.button}
         onPress={() => {
-          if (isPreviousRouteCommunityPostPermissionOrEditCommunity) {
+          if (isPreviousRouteCommunityPostPermissionOrEditCommunity()) {
             return navigation.pop(4);
           }
 

--- a/src/v4/elements/CommunityCover/CommunityCoverNavigator.tsx
+++ b/src/v4/elements/CommunityCover/CommunityCoverNavigator.tsx
@@ -51,11 +51,27 @@ const CommunityCoverNavigator: FC<CommunityCoverNavigatorProps> = ({
       tintColor: 'white',
     },
   });
+
+  const isPreviousRouteCommunityPostPermissionOrEditCommunity = () => {
+    const navigationState = navigation.getState();
+    const routes = navigationState.routes;
+    const currentIndex = navigationState.index;
+    const previousRoute = currentIndex > 0 ? routes[currentIndex - 1] : null;
+
+    return (
+      previousRoute?.name === 'CommunityPostPermission' ||
+      previousRoute?.name === 'EditCommunity'
+    );
+  };
   return (
     <View style={styles.container}>
       <Pressable
         style={styles.button}
         onPress={() => {
+          if (isPreviousRouteCommunityPostPermissionOrEditCommunity) {
+            return navigation.pop(4);
+          }
+
           if (pop === 2) {
             return navigation.pop(2);
           }


### PR DESCRIPTION
**Jira ticket :**

- https://socialplus.atlassian.net/browse/SP-32510
- https://socialplus.atlassian.net/browse/SP-32480

**Description :**
Fixed navigation when onBack on community profile and previous page is edit community or post permission page

**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

https://github.com/user-attachments/assets/dd767ec4-eacb-4172-a6dd-927ab4835d8f


**Note (optional) :**
