### PR TITLE
fix: SP-32502 - file type and story toast

### DIFF
--- a/src/v4/PublicApi/Pages/AmityDraftStoryPage/AmityDraftStoryPage.tsx
+++ b/src/v4/PublicApi/Pages/AmityDraftStoryPage/AmityDraftStoryPage.tsx
@@ -35,6 +35,8 @@ import { useFile } from '../../../hook/useFile';
 import { defaultAvatarUri } from '../../../assets/index';
 import { getMediaTypeFromUrl } from '../../../../util/urlUtil';
 import { LoadingOverlay } from '../../../../components/LoadingOverlay';
+import mime from 'mime';
+import { useToast } from '~/v4/stores/slices/toast';
 
 const AmityDraftStoryPage: FC<IAmityDraftStoryPage> = ({
   targetId,
@@ -71,6 +73,8 @@ const AmityDraftStoryPage: FC<IAmityDraftStoryPage> = ({
     },
     configKey: 'hyperlink_button_icon',
   });
+
+  const { showToast } = useToast();
 
   useEffect(() => {
     if (!targetId || targetType !== 'community')
@@ -117,7 +121,10 @@ const AmityDraftStoryPage: FC<IAmityDraftStoryPage> = ({
 
   const onPressShareStory = useCallback(async () => {
     const formData = new FormData();
-    formData.append('files', mediaType);
+    formData.append('files', {
+      ...mediaType,
+      type: mime.getType(mediaType.uri),
+    });
 
     try {
       setLoading(true);
@@ -140,12 +147,24 @@ const AmityDraftStoryPage: FC<IAmityDraftStoryPage> = ({
         );
       }
     } catch (error) {
-      Alert.alert('Create Story fail', error.message);
+      showToast({
+        message: 'Failed to share story. Please try again.',
+        type: 'informative',
+      });
     } finally {
       setLoading(false);
+      showToast({ message: 'Successfully shared story.', type: 'success' });
       onCreateStory();
     }
-  }, [hyperlink, imageDisplayMode, mediaType, onCreateStory, targetId, type]);
+  }, [
+    hyperlink,
+    imageDisplayMode,
+    mediaType,
+    onCreateStory,
+    showToast,
+    targetId,
+    type,
+  ]);
 
   const onHyperLinkSubmit = useCallback(
     (item?: { url: string; customText: string }) => {

--- a/src/v4/PublicApi/Pages/AmityDraftStoryPage/AmityDraftStoryPage.tsx
+++ b/src/v4/PublicApi/Pages/AmityDraftStoryPage/AmityDraftStoryPage.tsx
@@ -146,6 +146,8 @@ const AmityDraftStoryPage: FC<IAmityDraftStoryPage> = ({
           hyperlink
         );
       }
+
+      showToast({ message: 'Successfully shared story.', type: 'success' });
     } catch (error) {
       showToast({
         message: 'Failed to share story. Please try again.',
@@ -153,7 +155,6 @@ const AmityDraftStoryPage: FC<IAmityDraftStoryPage> = ({
       });
     } finally {
       setLoading(false);
-      showToast({ message: 'Successfully shared story.', type: 'success' });
       onCreateStory();
     }
   }, [


### PR DESCRIPTION
**Jira ticket :**
https://socialplus.atlassian.net/browse/SP-32502

**Description :**
- Fixed type on files
- Apply success toast and failed toast when create story
**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

https://github.com/user-attachments/assets/3ff86b03-a4ca-4aba-9f4d-5bacd437c46a


**Note (optional) :**
