### PR TITLE
feat: post deteted in livestream

### DIFF
--- a/src/v4/PublicApi/Pages/AmityCreateLivestreamPage/AmityCreateLivestreamPage.tsx
+++ b/src/v4/PublicApi/Pages/AmityCreateLivestreamPage/AmityCreateLivestreamPage.tsx
@@ -36,13 +36,13 @@ import { CancelCreateLivestreamButton } from '../../../elements/CancelCreateLive
 import { EndLiveStreamButton } from '../../../elements/EndLiveStreamButton';
 import { AddThumbnailButton } from '../../../elements/AddThumbnailButton';
 import { SwitchCameraButton } from '../../../elements/SwitchCameraButton';
-
 import { Track, LocalVideoTrack } from 'livekit-client';
 import { LiveKitRoom, registerGlobals } from '@livekit/react-native';
 import { RoomView } from './RoomView';
 import { Camera, useCameraDevice } from 'react-native-vision-camera';
 import { useRoomSubscription } from '../../../../v4/hook/useRoomSubscription';
 import { useToast } from '../../../../v4/stores/slices/toast';
+import { usePostSubscription } from '~/v4/hook';
 
 // Register WebRTC globals required for LiveKit
 registerGlobals();
@@ -91,6 +91,9 @@ function AmityCreateLivestreamPage() {
   const unsubscribeRef = useRef<Amity.Unsubscriber>(null);
 
   useRoomSubscription({ room });
+
+  const { subscribedPost } = usePostSubscription(post?.postId || '');
+
   const { showToast } = useToast();
 
   const frontCamera = useCameraDevice('front');
@@ -394,6 +397,17 @@ function AmityCreateLivestreamPage() {
       navigation.replace('LivestreamTerminated', { type: 'streamer' });
     }
   }, [room?.moderation?.terminateLabels, room?.status, navigation]);
+
+  useEffect(() => {
+    if (room?.isDeleted || subscribedPost?.isDeleted) {
+      navigation.replace('PostDetail', { postId: subscribedPost?.postId });
+    }
+  }, [
+    navigation,
+    room?.isDeleted,
+    subscribedPost?.postId,
+    subscribedPost?.isDeleted,
+  ]);
 
   useEffect(() => {
     const unsubscribe = unsubscribeRef.current;

--- a/src/v4/PublicApi/Pages/AmityCreateLivestreamPage/AmityCreateLivestreamPage.tsx
+++ b/src/v4/PublicApi/Pages/AmityCreateLivestreamPage/AmityCreateLivestreamPage.tsx
@@ -42,7 +42,7 @@ import { RoomView } from './RoomView';
 import { Camera, useCameraDevice } from 'react-native-vision-camera';
 import { useRoomSubscription } from '../../../../v4/hook/useRoomSubscription';
 import { useToast } from '../../../../v4/stores/slices/toast';
-import { usePostSubscription } from '~/v4/hook';
+import { usePostSubscription } from '../../../../v4/hook';
 
 // Register WebRTC globals required for LiveKit
 registerGlobals();

--- a/src/v4/PublicApi/Pages/AmityLivestreamPlayerPage/AmityLivestreamPlayerPage.tsx
+++ b/src/v4/PublicApi/Pages/AmityLivestreamPlayerPage/AmityLivestreamPlayerPage.tsx
@@ -66,7 +66,12 @@ function AmityLiveStreamPlayerPage() {
     if (room?.isDeleted || subscribedPost?.isDeleted) {
       navigation.replace('PostDetail', { postId: subscribedPost?.postId });
     }
-  }, [room?.isDeleted, subscribedPost, navigation]);
+  }, [
+    navigation,
+    room?.isDeleted,
+    subscribedPost?.postId,
+    subscribedPost?.isDeleted,
+  ]);
 
   useEffect(() => {
     const unsubscribe = NetInfo.addEventListener((state) => {


### PR DESCRIPTION
**Jira ticket :**

- https://socialplus.atlassian.net/browse/PDT-290

**Description :**

Livestream and post deletion handling:

* Added import and usage of the `usePostSubscription` hook to subscribe to post updates, enabling real-time detection of post deletion. 
* Introduced a `useEffect` that checks if either the livestream room or the associated post has been deleted, and if so, navigates the user to the `PostDetail` page for that post.

**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

https://github.com/user-attachments/assets/3b9f230b-96ea-45b3-b270-5409dfe4ea74

**Note (optional) :**
