### PR TITLE
feat: PDT-330 - cannot load recorded video in android

### DIFF
--- a/src/v4/PublicApi/Pages/AmityLivestreamPlayerPage/AmityLivestreamPlayerPage.tsx
+++ b/src/v4/PublicApi/Pages/AmityLivestreamPlayerPage/AmityLivestreamPlayerPage.tsx
@@ -230,6 +230,7 @@ function AmityLiveStreamPlayerPage() {
                 headers: {
                   Authorization: `Bearer ${client.token.accessToken}`,
                 },
+                type: 'm3u8',
               }}
               style={styles.container}
               resizeMode="contain"


### PR DESCRIPTION
**Jira ticket :**

- https://socialplus.atlassian.net/browse/PDT-330

**Description :**

This pull request introduces a small change to the `AmityLivestreamPlayerPage` component. The update adds a `type: 'm3u8'` property to the video player configuration, which likely ensures correct handling of HLS (HTTP Live Streaming) streams.

- Added the `type: 'm3u8'` property to the video player configuration in `AmityLivestreamPlayerPage.tsx` to specify the stream format.

**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

<img width="1475" height="975" alt="Screenshot 2026-01-20 at 12 14 27 PM" src="https://github.com/user-attachments/assets/224673ac-01f1-4f62-90c9-6d047bdfa2e1" />


**Note (optional) :**
