### PR TITLE
fix: PDT-333 - livestream ended ui

### DIFF
--- a/src/v4/PublicApi/Pages/AmityLivestreamPlayerPage/AmityLivestreamPlayerPage.tsx
+++ b/src/v4/PublicApi/Pages/AmityLivestreamPlayerPage/AmityLivestreamPlayerPage.tsx
@@ -29,9 +29,8 @@ function AmityLiveStreamPlayerPage() {
 
   const [reconnecting, setReconnecting] = useState(false);
   const [room, setRoom] = useState<Amity.Room | null>(null);
-  const [videoError, setVideoError] = useState(false);
   const [error, setError] = useState<Error | null>(null);
-  const [, setPlayerInitialized] = useState(false);
+  const [isVideoLoading, setIsVideoLoading] = useState(true);
   const [videoKey, setVideoKey] = useState(0);
   const [isPaused, setIsPaused] = useState(false);
   const [wasLive, setWasLive] = useState(false);
@@ -105,34 +104,6 @@ function AmityLiveStreamPlayerPage() {
     }
   }, [room?.status, wasLive]);
 
-  useEffect(() => {
-    let timer: ReturnType<typeof setTimeout> | null = null;
-
-    if (
-      videoRef.current &&
-      room &&
-      room.status === RoomStatus.live &&
-      !videoError &&
-      Platform.OS === 'ios'
-    ) {
-      const isTerminated =
-        room?.moderation?.terminateLabels &&
-        room?.moderation?.terminateLabels?.length > 0;
-
-      if (!isTerminated) {
-        timer = setTimeout(() => {
-          videoRef.current?.presentFullscreenPlayer();
-        }, 100);
-      }
-    }
-
-    return () => {
-      if (timer !== null) {
-        clearTimeout(timer);
-      }
-    };
-  }, [room, videoError]);
-
   const isTerminated =
     room?.moderation?.terminateLabels &&
     room?.moderation?.terminateLabels?.length > 0;
@@ -141,33 +112,6 @@ function AmityLiveStreamPlayerPage() {
     room?.status === RoomStatus.ended ||
     (room?.status === RoomStatus.recorded && wasLive) ||
     isTerminated;
-
-  useEffect(() => {
-    if (!room?.status) return;
-
-    const shouldEnd =
-      room.status === RoomStatus.ended ||
-      (room.status === RoomStatus.recorded && wasLive);
-
-    if (!shouldEnd || isStreamEnding.current) return;
-
-    isStreamEnding.current = true;
-    setIsPaused(true);
-
-    if (Platform.OS === 'ios') {
-      // iOS: just dismiss fullscreen, DO NOT destroy immediately
-      if (videoRef.current) {
-        try {
-          videoRef.current.dismissFullscreenPlayer?.();
-        } catch {}
-      }
-    } else {
-      // Android: HARD destroy
-      setTimeout(() => {
-        setVideoKey((prev) => prev + 1);
-      }, 50);
-    }
-  }, [room?.status, wasLive]);
 
   if (!room || error) {
     return (
@@ -233,10 +177,7 @@ function AmityLiveStreamPlayerPage() {
               }}
               style={styles.container}
               resizeMode="contain"
-              controls={room?.status === RoomStatus.recorded && !wasLive}
-              fullscreen={
-                Platform.OS === 'ios' && room.status !== RoomStatus.recorded
-              }
+              controls={true}
               fullscreenOrientation="landscape"
               paused={isPaused}
               muted={false}
@@ -246,21 +187,18 @@ function AmityLiveStreamPlayerPage() {
               playWhenInactive={false}
               repeat={false}
               onLoad={() => {
-                setPlayerInitialized(true);
+                setIsVideoLoading(false);
                 if (room.status === RoomStatus.recorded) {
                   setIsPaused(false);
                 }
               }}
-              onError={(e) => {
-                console.log('Video Error: ', e);
-                setVideoError(true);
-              }}
-              onFullscreenPlayerDidDismiss={() => {
-                if (Platform.OS === 'ios') {
-                  closePlayer();
-                }
-              }}
             />
+          )}
+
+          {isVideoLoading && (
+            <View style={styles.connecting}>
+              <CircularProgressIndicator size={40} strokeWidth={2} />
+            </View>
           )}
         </View>
       )}


### PR DESCRIPTION
**Jira ticket :**

- https://socialplus.atlassian.net/browse/PDT-333

**Description :**

**Video player logic and UI improvements:**

* Removed platform-specific (iOS/Android) fullscreen presentation and dismissal logic, including the use of timers and conditional fullscreen handling. This simplifies the code and unifies the player experience across platforms.
* Always enables video player controls by setting the `controls` prop to `true`, rather than conditionally showing controls based on the stream status.
* Replaced the previous video loading and error state management (`videoError`, `setPlayerInitialized`) with a single `isVideoLoading` state, and added a loading indicator (`CircularProgressIndicator`) while the video is loading. 
* Removed the `onError` and `onFullscreenPlayerDidDismiss` handlers, further streamlining the player component and error handling.

**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

https://github.com/user-attachments/assets/363804cc-376d-4eca-9b81-31bf6d8e3333

**Note (optional) :**
