### PR TITLE
fix: PDT-291 - 3 mins end live stream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ project.xcworkspace
 .settings
 local.properties
 android.iml
+.kotlin
 
 # Cocoapods
 #

--- a/example/package.json
+++ b/example/package.json
@@ -6,10 +6,14 @@
     "android": "react-native run-android",
     "ios": "react-native run-ios",
     "start": "react-native start",
-    "pods": "pod-install --quiet"
+    "pods": "pod-install --quiet",
+    "ios:pod": "cd ios && pod install",
+    "android:clean": "cd android && ./gradlew clean",
+    "android:debug": "cd android && ./gradlew assembleDebug",
+    "android:release": "cd android && ./gradlew assembleRelease"
   },
   "dependencies": {
-    "@amityco/ts-sdk-react-native": "7.12.1-6e066c82.0",
+    "@amityco/ts-sdk-react-native": "^7.12.0",
     "@babel/plugin-transform-export-namespace-from": "^7.27.1",
     "@livekit/react-native": "^2.9.6",
     "@livekit/react-native-webrtc": "^137.0.2",

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@amityco/ts-sdk-react-native@7.12.1-6e066c82.0":
-  version "7.12.1-6e066c82.0"
-  resolved "https://registry.yarnpkg.com/@amityco/ts-sdk-react-native/-/ts-sdk-react-native-7.12.1-6e066c82.0.tgz#af46a517183978a9127785ae1ac2144d4c2e21e0"
-  integrity sha512-IrYhabk6ygWSHKTCfg+AQADZ79w3RXiELVo5lKlqC7z3VE14gzwbFKRnBwRUV9gLkWP1UejqD8A3kI3Y2xsJMQ==
+"@amityco/ts-sdk-react-native@^7.12.0":
+  version "7.12.0"
+  resolved "https://registry.yarnpkg.com/@amityco/ts-sdk-react-native/-/ts-sdk-react-native-7.12.0.tgz#644c1ef711050bd99d2a69b6827e705b7a4402b5"
+  integrity sha512-jn2ScxrqLMl4oi1E6zX0ZpLZmLj5Fo0NC6oThh5GZ09CD7kVB39b0z9EVWvs65mnUM+Owb+G5zc6qcGg3+ECAA==
   dependencies:
     "@react-native-async-storage/async-storage" "^1.17.7"
     "@react-native-community/netinfo" "^9.4.1"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,14 @@
     "build:android": "cd example/android && ./gradlew assembleDebug --no-daemon --console=plain -PreactNativeArchitectures=arm64-v8a",
     "build:ios": "cd example/ios && xcodebuild -workspace AmityReactNativeSocialUiKitExample.xcworkspace -scheme AmityReactNativeSocialUiKitExample -configuration Debug -sdk iphonesimulator CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ GCC_OPTIMIZATION_LEVEL=0 GCC_PRECOMPILE_PREFIX_HEADER=YES ASSETCATALOG_COMPILER_OPTIMIZATION=time DEBUG_INFORMATION_FORMAT=dwarf COMPILER_INDEX_STORE_ENABLE=NO",
     "bootstrap": "yarn example && yarn install && yarn example pods",
-    "clean": "del-cli android/build example/android/build example/android/app/build example/ios/build"
+    "clean": "del-cli android/build example/android/build example/android/app/build example/ios/build",
+    "install": "yarn",
+    "ios:pod": "cd example/ios && pod install",
+    "android:clean": "cd example/android && ./gradlew clean",
+    "android:debug": "cd example/android && ./gradlew assembleDebug",
+    "android:release": "cd example/android && ./gradlew assembleRelease",
+    "android:run": "cd example && react-native run-android",
+    "ios:run": "cd example && react-native run-ios"
   },
   "keywords": [
     "react-native",

--- a/package.json
+++ b/package.json
@@ -39,14 +39,7 @@
     "build:android": "cd example/android && ./gradlew assembleDebug --no-daemon --console=plain -PreactNativeArchitectures=arm64-v8a",
     "build:ios": "cd example/ios && xcodebuild -workspace AmityReactNativeSocialUiKitExample.xcworkspace -scheme AmityReactNativeSocialUiKitExample -configuration Debug -sdk iphonesimulator CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ GCC_OPTIMIZATION_LEVEL=0 GCC_PRECOMPILE_PREFIX_HEADER=YES ASSETCATALOG_COMPILER_OPTIMIZATION=time DEBUG_INFORMATION_FORMAT=dwarf COMPILER_INDEX_STORE_ENABLE=NO",
     "bootstrap": "yarn example && yarn install && yarn example pods",
-    "clean": "del-cli android/build example/android/build example/android/app/build example/ios/build",
-    "install": "yarn",
-    "ios:pod": "cd example/ios && pod install",
-    "android:clean": "cd example/android && ./gradlew clean",
-    "android:debug": "cd example/android && ./gradlew assembleDebug",
-    "android:release": "cd example/android && ./gradlew assembleRelease",
-    "android:run": "cd example && react-native run-android",
-    "ios:run": "cd example && react-native run-ios"
+    "clean": "del-cli android/build example/android/build example/android/app/build example/ios/build"
   },
   "keywords": [
     "react-native",
@@ -64,7 +57,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "devDependencies": {
-    "@amityco/ts-sdk-react-native": "7.12.1-6e066c82.0",
+    "@amityco/ts-sdk-react-native": "^7.12.0",
     "@babel/plugin-transform-export-namespace-from": "^7.27.1",
     "@commitlint/config-conventional": "^17.0.2",
     "@evilmartians/lefthook": "^1.2.2",
@@ -123,7 +116,7 @@
     "@types/react": "18.2.37"
   },
   "peerDependencies": {
-    "@amityco/ts-sdk-react-native": "7.12.1-6e066c82.0",
+    "@amityco/ts-sdk-react-native": "^7.12.0",
     "@livekit/react-native": "^2.9.6",
     "@livekit/react-native-webrtc": "^137.0.2",
     "@react-native-async-storage/async-storage": "^1.19.3",

--- a/src/v4/PublicApi/Pages/AmityCreateLivestreamPage/AmityCreateLivestreamPage.tsx
+++ b/src/v4/PublicApi/Pages/AmityCreateLivestreamPage/AmityCreateLivestreamPage.tsx
@@ -80,6 +80,9 @@ function AmityCreateLivestreamPage() {
   const [post, setPost] = useState<Amity.Post | null>(null);
   const [roomId, setRoomId] = useState<string>('');
   const timerRef = useRef<number | null>(null);
+  const connectionLossTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null
+  );
   const [isConnecting, setIsConnecting] = useState<boolean>(false);
   const [androidPermission, setAndroidPermission] = useState<boolean>(false);
   const [iOSPermission, setIOSPermission] = useState<boolean>(true);
@@ -373,21 +376,24 @@ function AmityCreateLivestreamPage() {
   }, []);
 
   useEffect(() => {
-    let threeMinutesTimeout: number;
-
-    if (reconnecting && room && room?.status === RoomStatus.live) {
-      threeMinutesTimeout = setTimeout(() => {
+    if (reconnecting && room?.status === RoomStatus.live) {
+      connectionLossTimeoutRef.current = setTimeout(() => {
         endLiveStream();
       }, 1000 * 60 * 3);
-    }
-
-    if (!reconnecting && room && room?.status === RoomStatus.live) {
-      if (threeMinutesTimeout) {
-        clearTimeout(threeMinutesTimeout);
-        threeMinutesTimeout = null;
+    } else {
+      if (connectionLossTimeoutRef.current) {
+        clearTimeout(connectionLossTimeoutRef.current);
+        connectionLossTimeoutRef.current = null;
       }
     }
-  }, [reconnecting, endLiveStream, room]);
+
+    return () => {
+      if (connectionLossTimeoutRef.current) {
+        clearTimeout(connectionLossTimeoutRef.current);
+        connectionLossTimeoutRef.current = null;
+      }
+    };
+  }, [reconnecting, endLiveStream, room?.status]);
 
   useEffect(() => {
     const isTerminated = room?.status === RoomStatus.terminated;
@@ -449,6 +455,9 @@ function AmityCreateLivestreamPage() {
             onConnected={() => {
               setIsConnecting(false);
               setReconnecting(false);
+            }}
+            onDisconnected={() => {
+              setReconnecting(true);
             }}
           >
             <View style={styles.cameraContainer}>

--- a/src/v4/PublicApi/Pages/AmityCreateLivestreamPage/AmityCreateLivestreamPage.tsx
+++ b/src/v4/PublicApi/Pages/AmityCreateLivestreamPage/AmityCreateLivestreamPage.tsx
@@ -396,12 +396,14 @@ function AmityCreateLivestreamPage() {
   }, [reconnecting, endLiveStream, room?.status]);
 
   useEffect(() => {
-    const isTerminated = room?.status === RoomStatus.terminated;
+    const isTerminated =
+      room?.moderation?.terminateLabels &&
+      room?.moderation?.terminateLabels?.length > 0;
 
     if (isTerminated) {
       navigation.replace('LivestreamTerminated', { type: 'streamer' });
     }
-  }, [room?.status, navigation]);
+  }, [room?.moderation?.terminateLabels, navigation]);
 
   useEffect(() => {
     if (room?.isDeleted || subscribedPost?.isDeleted) {

--- a/src/v4/PublicApi/Pages/AmityLivestreamPlayerPage/AmityLivestreamPlayerPage.tsx
+++ b/src/v4/PublicApi/Pages/AmityLivestreamPlayerPage/AmityLivestreamPlayerPage.tsx
@@ -105,11 +105,14 @@ function AmityLiveStreamPlayerPage() {
   }, [room?.status, wasLive]);
 
   useEffect(() => {
-    const isTerminated = room?.status === RoomStatus.terminated;
+    const isTerminated =
+      room?.moderation?.terminateLabels &&
+      room?.moderation?.terminateLabels?.length > 0;
+
     if (isTerminated) {
       navigation.replace('LivestreamTerminated', { type: 'viewer' });
     }
-  }, [room?.status, navigation]);
+  }, [room?.moderation?.terminateLabels, navigation]);
 
   const shouldShowEndThumbnail =
     room?.status === RoomStatus.ended ||

--- a/src/v4/enum/roomStatus.ts
+++ b/src/v4/enum/roomStatus.ts
@@ -4,5 +4,4 @@ export const RoomStatus = {
   recorded: 'recorded',
   ended: 'ended',
   waitingReconnect: 'waitingReconnect',
-  terminated: 'terminated',
 } as const satisfies Record<Amity.RoomStatus, Amity.RoomStatus>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@amityco/ts-sdk-react-native@7.12.1-6e066c82.0":
-  version "7.12.1-6e066c82.0"
-  resolved "https://registry.yarnpkg.com/@amityco/ts-sdk-react-native/-/ts-sdk-react-native-7.12.1-6e066c82.0.tgz#af46a517183978a9127785ae1ac2144d4c2e21e0"
-  integrity sha512-IrYhabk6ygWSHKTCfg+AQADZ79w3RXiELVo5lKlqC7z3VE14gzwbFKRnBwRUV9gLkWP1UejqD8A3kI3Y2xsJMQ==
+"@amityco/ts-sdk-react-native@^7.12.0":
+  version "7.12.0"
+  resolved "https://registry.yarnpkg.com/@amityco/ts-sdk-react-native/-/ts-sdk-react-native-7.12.0.tgz#644c1ef711050bd99d2a69b6827e705b7a4402b5"
+  integrity sha512-jn2ScxrqLMl4oi1E6zX0ZpLZmLj5Fo0NC6oThh5GZ09CD7kVB39b0z9EVWvs65mnUM+Owb+G5zc6qcGg3+ECAA==
   dependencies:
     "@react-native-async-storage/async-storage" "^1.17.7"
     "@react-native-community/netinfo" "^9.4.1"


### PR DESCRIPTION
**Jira ticket :**

- https://socialplus.atlassian.net/browse/PDT-291

**Description :**

**Livestream Room Status Handling:**

* Refactored termination detection logic in both `AmityCreateLivestreamPage.tsx` and `AmityLivestreamPlayerPage.tsx` to use `room.moderation.terminateLabels` instead of relying on the removed `RoomStatus.terminated` status. This ensures termination is detected based on moderation labels, improving reliability. 
* Updated the effect dependencies and logic to react to changes in moderation labels, ensuring navigation to the termination page is triggered correctly.

**Connection Loss and Timeout Management:**

* Replaced the previous local timeout variable with a `connectionLossTimeoutRef` to properly manage and clear timeouts when reconnecting or disconnecting from a livestream, preventing potential memory leaks and ensuring correct end-of-stream behavior. 
* Added an `onDisconnected` handler to set the reconnecting state when the livestream disconnects, improving the user experience during connection interruptions.

**Build and Dependency Scripts:**

* Added new npm scripts to `example/package.json` for iOS pod installation and Android build/clean operations, streamlining local development workflows.
* Updated the version specifier for `@amityco/ts-sdk-react-native` in `package.json` and `example/package.json` from an exact version to a compatible range (`^7.12.0`), ensuring smoother dependency updates and compatibility.

**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

https://github.com/user-attachments/assets/b7b28f57-b9b4-458d-97bf-c50325f888b5

**Note (optional) :**
