### PR TITLE
fix: import path

### DIFF
--- a/src/v4/PublicApi/Pages/AmityViewStoryPage/Components/AmityViewStoryItem.tsx
+++ b/src/v4/PublicApi/Pages/AmityViewStoryPage/Components/AmityViewStoryItem.tsx
@@ -43,7 +43,7 @@ import { Typography } from '../../../../component/Typography/Typography';
 import { useTheme } from 'react-native-paper';
 import { MyMD3Theme } from '../../../../../providers/amity-ui-kit-provider';
 import { useUIKitDispatch } from '../../../../../redux/store';
-import { informative } from '~/v4/assets/icons/toast';
+import { informative } from '../../../../../v4/assets/icons/toast';
 import { close as closeIcon } from '../../../../assets/icons';
 
 interface IAmityViewStoryItem {


### PR DESCRIPTION
**Jira ticket :**

- N/A

**Description :**

This pull request makes a minor update to the import path for the `informative` icon in the `AmityViewStoryItem` component. The new path uses a relative import instead of a tilde alias to ensure consistency and compatibility with the project's directory structure.

**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

**Note (optional) :**
