### PR TITLE
feat: PDT-368 - no internet connection toast and terminated

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - amity-react-native-social-ui-kit (4.0.0-RC11):
+  - amity-react-native-social-ui-kit (4.0.0-RC13):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2264,7 +2264,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  amity-react-native-social-ui-kit: 02d6a9ea9c3265609f7861e644465bfc74b2cc35
+  amity-react-native-social-ui-kit: 6c9cebdce86fbee61dd2a1955921c6e8bcbfbdb9
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   BVLinearGradient: cb006ba232a1f3e4f341bb62c42d1098c284da70
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb

--- a/example/package.json
+++ b/example/package.json
@@ -13,7 +13,7 @@
     "android:release": "cd android && ./gradlew assembleRelease"
   },
   "dependencies": {
-    "@amityco/ts-sdk-react-native": "7.12.1-b52ac434.0",
+    "@amityco/ts-sdk-react-native": "7.12.1-7200581b.0",
     "@babel/plugin-transform-export-namespace-from": "^7.27.1",
     "@livekit/react-native": "^2.9.6",
     "@livekit/react-native-webrtc": "^137.0.2",

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -2,15 +2,15 @@
 # yarn lockfile v1
 
 
-"@amityco/ts-sdk-react-native@7.12.1-b52ac434.0":
-  version "7.12.1-b52ac434.0"
-  resolved "https://registry.yarnpkg.com/@amityco/ts-sdk-react-native/-/ts-sdk-react-native-7.12.1-b52ac434.0.tgz#fde5b30885bad5e24634321bf00e34cb9885bf10"
-  integrity sha512-lv8jl+pcBqkujfoxBfsBGvRvUX08XvhvqD+BpTuU7JExdHseHBYG9aVgwR892LuIbWzot9mr31tEN+v8ljrxvg==
+"@amityco/ts-sdk-react-native@7.12.1-7200581b.0":
+  version "7.12.1-7200581b.0"
+  resolved "https://registry.yarnpkg.com/@amityco/ts-sdk-react-native/-/ts-sdk-react-native-7.12.1-7200581b.0.tgz#14eb4689256924c839a5e349509c59c7df91f67b"
+  integrity sha512-r1xLjyn2x8khGaDiXuu/rpWejhqDUUKljCjrLc5C7P3bLyGjSfV7k6KPaMC13YuKIUjYQvLNTYhrj7kZAWlaRw==
   dependencies:
     "@react-native-async-storage/async-storage" "^1.17.7"
     "@react-native-community/netinfo" "^9.4.1"
     agentkeepalive "^4.2.1"
-    axios "^1.2.3"
+    axios "1.2.3"
     debug "^4.3.4"
     hls.js "^1.4.10"
     js-base64 "^3.7.2"
@@ -3126,13 +3126,13 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
-axios@^1.2.3:
-  version "1.13.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.13.2.tgz#9ada120b7b5ab24509553ec3e40123521117f687"
-  integrity sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==
+axios@1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.2.3.tgz#31a3d824c0ebf754a004b585e5f04a5f87e6c4ff"
+  integrity sha512-pdDkMYJeuXLZ6Xj/Q5J3Phpe+jbGdsSzlQaFVkMQzRUL05+6+tetX8TV3p4HrU4kzuO9bt+io/yGQxuyxA/xcw==
   dependencies:
-    follow-redirects "^1.15.6"
-    form-data "^4.0.4"
+    follow-redirects "^1.15.0"
+    form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
 babel-jest@^29.7.0:
@@ -4535,7 +4535,7 @@ flow-parser@0.*:
   resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.273.1.tgz#809bae16ae5661dd360a1172bec36ed87fe7a69c"
   integrity sha512-UTTfeYIhxYJ7xuW+HL9oyx6lnUGx1+W5Cyo8hOPgMrDU49GANfONtkb9dguDvIyQ20fz8CHZwB25ZP2206bBWQ==
 
-follow-redirects@^1.15.6:
+follow-redirects@^1.15.0:
   version "1.15.11"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.11.tgz#777d73d72a92f8ec4d2e410eb47352a56b8e8340"
   integrity sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==
@@ -4564,7 +4564,7 @@ for-own@^1.0.0:
   dependencies:
     for-in "^1.0.1"
 
-form-data@^4.0.4:
+form-data@^4.0.0:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.5.tgz#b49e48858045ff4cbf6b03e1805cebcad3679053"
   integrity sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "devDependencies": {
-    "@amityco/ts-sdk-react-native": "7.12.1-b52ac434.0",
+    "@amityco/ts-sdk-react-native": "7.12.1-7200581b.0",
     "@babel/plugin-transform-export-namespace-from": "^7.27.1",
     "@commitlint/config-conventional": "^17.0.2",
     "@evilmartians/lefthook": "^1.2.2",
@@ -116,7 +116,7 @@
     "@types/react": "18.2.37"
   },
   "peerDependencies": {
-    "@amityco/ts-sdk-react-native": "7.12.1-b52ac434.0",
+    "@amityco/ts-sdk-react-native": "7.12.1-7200581b.0",
     "@livekit/react-native": "^2.9.6",
     "@livekit/react-native-webrtc": "^137.0.2",
     "@react-native-async-storage/async-storage": "^1.19.3",

--- a/src/v4/PublicApi/Components/AmityCreatePostMenuComponent/AmityCreatePostMenuComponent.tsx
+++ b/src/v4/PublicApi/Components/AmityCreatePostMenuComponent/AmityCreatePostMenuComponent.tsx
@@ -7,7 +7,7 @@ import { useNavigation } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { RootStackParamList } from '../../../../v4/routes/RouteParamList';
 import { AmityPostTargetSelectionPageType } from '../../../enum';
-import { livestream, poll, post, story } from '~/v4/assets/icons';
+import { livestream, poll, post, story } from '../../../../v4/assets/icons';
 import MenuAction from '../../../../v4/elements/MenuAction';
 
 interface AmityCreatePostMenuComponentProps {

--- a/src/v4/PublicApi/Components/AmityPostCommentComponent/AmityPostCommentComponent.tsx
+++ b/src/v4/PublicApi/Components/AmityPostCommentComponent/AmityPostCommentComponent.tsx
@@ -15,13 +15,11 @@ import { deleteCommentById } from '../../../../providers/Social/comment-sdk';
 import { ComponentID, PageID } from '../../../enum';
 import { useAmityComponent } from '../../../hook';
 import ContentLoader, { Circle, Rect } from 'react-content-loader/native';
-import uiSlice from '../../../../redux/slices/uiSlice';
 import { isAmityAd } from '../../../hook/useCustomRankingGlobalFeed';
 import CommentAdComponent from '../../../component/CommentAdComponent/CommentAdComponent';
 import { usePaginatorApi } from '../../../hook/usePaginator';
 import { useCommentAdImpression } from '../../../hook/useCommentAdImpression';
 import { useStyles } from './styles';
-import { useUIKitDispatch } from '../../../../redux/store';
 
 export interface IComment {
   commentId: string;
@@ -69,8 +67,6 @@ const AmityPostCommentComponent: FC<AmityPostCommentComponentType> = ({
     componentId,
   });
   const styles = useStyles();
-  const dispatch = useUIKitDispatch();
-  const { showToastMessage } = uiSlice.actions;
   const onNextPageRef = useRef<() => void | null>(null);
   const [commentList, setCommentList] = useState<IComment[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -109,7 +105,7 @@ const AmityPostCommentComponent: FC<AmityPostCommentComponentType> = ({
       setCommentList([]);
       unsubComment();
     };
-  }, [dispatch, postId, postType, showToastMessage]);
+  }, [postId, postType]);
 
   const queryComment = async (comments: Amity.InternalComment[]) => {
     const formattedCommentList = await Promise.all(

--- a/src/v4/PublicApi/Components/AmityPostCommentComponent/AmityPostCommentComponent.tsx
+++ b/src/v4/PublicApi/Components/AmityPostCommentComponent/AmityPostCommentComponent.tsx
@@ -95,11 +95,7 @@ const AmityPostCommentComponent: FC<AmityPostCommentComponentType> = ({
         referenceType: postType,
         limit: commentListLimit,
       },
-      async ({ error, loading, data, hasNextPage, onNextPage }) => {
-        if (error) {
-          dispatch(showToastMessage({ toastMessage: "Couldn't load comment" }));
-          return;
-        }
+      async ({ loading, data, hasNextPage, onNextPage }) => {
         if (!loading) {
           data && data.length > 0 && (await queryComment(data));
           onNextPageRef.current = hasNextPage ? onNextPage : null;

--- a/src/v4/PublicApi/Pages/AmityCreateLivestreamPage/AmityCreateLivestreamPage.tsx
+++ b/src/v4/PublicApi/Pages/AmityCreateLivestreamPage/AmityCreateLivestreamPage.tsx
@@ -396,14 +396,10 @@ function AmityCreateLivestreamPage() {
   }, [reconnecting, endLiveStream, room?.status]);
 
   useEffect(() => {
-    const isTerminated =
-      room?.moderation?.terminateLabels &&
-      room?.moderation?.terminateLabels?.length > 0;
-
-    if (isTerminated) {
+    if (room?.status === RoomStatus.terminated) {
       navigation.replace('LivestreamTerminated', { type: 'streamer' });
     }
-  }, [room?.moderation?.terminateLabels, navigation]);
+  }, [room?.status, navigation]);
 
   useEffect(() => {
     if (room?.isDeleted || subscribedPost?.isDeleted) {

--- a/src/v4/PublicApi/Pages/AmityLivestreamPlayerPage/AmityLivestreamPlayerPage.tsx
+++ b/src/v4/PublicApi/Pages/AmityLivestreamPlayerPage/AmityLivestreamPlayerPage.tsx
@@ -108,14 +108,10 @@ function AmityLiveStreamPlayerPage() {
   }, [room?.status, wasLive]);
 
   useEffect(() => {
-    const isTerminated =
-      room?.moderation?.terminateLabels &&
-      room?.moderation?.terminateLabels?.length > 0;
-
-    if (isTerminated) {
+    if (room?.status === RoomStatus.terminated) {
       navigation.replace('LivestreamTerminated', { type: 'viewer' });
     }
-  }, [room?.moderation?.terminateLabels, navigation]);
+  }, [room?.status, navigation]);
 
   const shouldShowEndThumbnail =
     room?.status === RoomStatus.ended ||

--- a/src/v4/PublicApi/Pages/AmityPostDetailPage/AmityPostDetailPage.tsx
+++ b/src/v4/PublicApi/Pages/AmityPostDetailPage/AmityPostDetailPage.tsx
@@ -40,6 +40,8 @@ import { closeIcon } from '../../../../svg/svg-xml-list';
 import { SvgXml } from 'react-native-svg';
 import { IMentionPosition } from '../../../../types';
 import uiSlice from '../../../../redux/slices/uiSlice';
+import NetInfo from '@react-native-community/netinfo';
+import { useToast } from '../../../../v4/stores/slices/toast';
 import MyAvatar from '../../../../v4/component/MyAvatar/MyAvatar';
 import {
   comment_contains_inapproproate_word,
@@ -82,6 +84,7 @@ const AmityPostDetailPage: FC<AmityPostDetailPageType> = ({
     useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   const { isExcluded, themeStyles, accessibilityId } = useAmityPage({ pageId });
   const styles = useStyles(themeStyles);
+  const { showToast } = useToast();
   const [postData, setPostData] = useState<Amity.Post<any>>(null);
   const [loading, setLoading] = useState<boolean>(true);
 
@@ -109,6 +112,20 @@ const AmityPostDetailPage: FC<AmityPostDetailPageType> = ({
   });
 
   const { showToastMessage } = uiSlice.actions;
+
+  useEffect(() => {
+    const unsubscribe = NetInfo.addEventListener((state) => {
+      if (!state.isConnected) {
+        showToast({
+          type: 'failed',
+          message: 'No internet connection.',
+          duration: 3000,
+          bottomPosition: 96,
+        });
+      }
+    });
+    return () => unsubscribe();
+  }, [showToast]);
 
   useLayoutEffect(() => {
     if (!postId) return () => {};

--- a/src/v4/enum/roomStatus.ts
+++ b/src/v4/enum/roomStatus.ts
@@ -4,4 +4,5 @@ export const RoomStatus = {
   recorded: 'recorded',
   ended: 'ended',
   waitingReconnect: 'waitingReconnect',
+  terminated: 'terminated',
 } as const satisfies Record<Amity.RoomStatus, Amity.RoomStatus>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,15 +2,15 @@
 # yarn lockfile v1
 
 
-"@amityco/ts-sdk-react-native@7.12.1-b52ac434.0":
-  version "7.12.1-b52ac434.0"
-  resolved "https://registry.yarnpkg.com/@amityco/ts-sdk-react-native/-/ts-sdk-react-native-7.12.1-b52ac434.0.tgz#fde5b30885bad5e24634321bf00e34cb9885bf10"
-  integrity sha512-lv8jl+pcBqkujfoxBfsBGvRvUX08XvhvqD+BpTuU7JExdHseHBYG9aVgwR892LuIbWzot9mr31tEN+v8ljrxvg==
+"@amityco/ts-sdk-react-native@7.12.1-7200581b.0":
+  version "7.12.1-7200581b.0"
+  resolved "https://registry.yarnpkg.com/@amityco/ts-sdk-react-native/-/ts-sdk-react-native-7.12.1-7200581b.0.tgz#14eb4689256924c839a5e349509c59c7df91f67b"
+  integrity sha512-r1xLjyn2x8khGaDiXuu/rpWejhqDUUKljCjrLc5C7P3bLyGjSfV7k6KPaMC13YuKIUjYQvLNTYhrj7kZAWlaRw==
   dependencies:
     "@react-native-async-storage/async-storage" "^1.17.7"
     "@react-native-community/netinfo" "^9.4.1"
     agentkeepalive "^4.2.1"
-    axios "^1.2.3"
+    axios "1.2.3"
     debug "^4.3.4"
     hls.js "^1.4.10"
     js-base64 "^3.7.2"
@@ -3689,13 +3689,13 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
-axios@^1.2.3:
-  version "1.13.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.13.2.tgz#9ada120b7b5ab24509553ec3e40123521117f687"
-  integrity sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==
+axios@1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.2.3.tgz#31a3d824c0ebf754a004b585e5f04a5f87e6c4ff"
+  integrity sha512-pdDkMYJeuXLZ6Xj/Q5J3Phpe+jbGdsSzlQaFVkMQzRUL05+6+tetX8TV3p4HrU4kzuO9bt+io/yGQxuyxA/xcw==
   dependencies:
-    follow-redirects "^1.15.6"
-    form-data "^4.0.4"
+    follow-redirects "^1.15.0"
+    form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
 babel-jest@^29.7.0:
@@ -5973,7 +5973,7 @@ flow-parser@0.*:
   resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.274.0.tgz#dfd8e7ecd483713b979e25fab4e7d9da3bb3d7c3"
   integrity sha512-pwmoGcWUSyamhv1DWhSFBROYqBfVJ/XAjqAdcrKSaisn5vI5dQ0Ni0Lawrp03TE2ZPC69vseFdeWkYlpCAqxtw==
 
-follow-redirects@^1.15.6:
+follow-redirects@^1.15.0:
   version "1.15.11"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.11.tgz#777d73d72a92f8ec4d2e410eb47352a56b8e8340"
   integrity sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==
@@ -6007,7 +6007,7 @@ form-data-encoder@^2.1.2:
   resolved "https://registry.yarnpkg.com/form-data-encoder/-/form-data-encoder-2.1.4.tgz#261ea35d2a70d48d30ec7a9603130fa5515e9cd5"
   integrity sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==
 
-form-data@^4.0.4:
+form-data@^4.0.0:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.5.tgz#b49e48858045ff4cbf6b03e1805cebcad3679053"
   integrity sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==


### PR DESCRIPTION
**Jira ticket :**

- https://socialplus.atlassian.net/browse/PDT-368
- https://socialplus.atlassian.net/browse/PDT-369

**Description :**

**Dependency Updates:**
- Updated all references to `@amityco/ts-sdk-react-native` from version `7.12.1-b52ac434.0` to `7.12.1-7200581b.0` in `package.json`, `example/package.json`, and peer dependencies. 

**Livestream Termination Logic Improvements:**
- Changed the logic in both `AmityCreateLivestreamPage` and `AmityLivestreamPlayerPage` to detect livestream termination based on `room.status === RoomStatus.terminated` instead of checking for `moderation.terminateLabels`. This makes the code more robust and consistent. 
- Added a new `terminated` status to the `RoomStatus` enum to support the above logic.

**User Feedback and Error Handling:**
- Added a network connectivity listener to `AmityPostDetailPage` that shows a toast notification if the user loses internet connection. This improves user awareness of connectivity issues. 
- Simplified error handling in `AmityPostCommentComponent` by removing redundant error checks, relying on loading state instead.

**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

https://github.com/user-attachments/assets/06c3151d-36d7-4115-b0b3-2bbddba46d1d

https://github.com/user-attachments/assets/f0cf330b-816a-4e6d-931f-1673bd55046f

**Note (optional) :**