### PR TITLE
feat: PDT-1315 - only admin can post

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amityco/react-native-social-uikit",
-  "version": "4.0.0-RC17",
+  "version": "4.0.0-RC18",
   "description": "Social UIKit",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/v4/PublicApi/Pages/AmityCommunityProfilePage/AmityCommunityProfilePage.tsx
+++ b/src/v4/PublicApi/Pages/AmityCommunityProfilePage/AmityCommunityProfilePage.tsx
@@ -41,6 +41,7 @@ import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
 import { useTheme } from 'react-native-paper';
 import { MyMD3Theme } from '../../../../providers/amity-ui-kit-provider';
 import AmityCommunityPinnedPostComponent from '../../../../v4/PublicApi/Components/AmityCommunityPinnedPostComponent/AmityCommunityPinnedPostComponent';
+import { usePostPermission } from '../../../../v4/hook/usePostPermission';
 
 type ICommunityProfilePage = {
   defaultCommunityId?: string;
@@ -273,6 +274,8 @@ function CommunityProfileActions({ pageId, communityId, styles }) {
 
   const hasStoryPermission = useStoryPermission(communityId);
 
+  const hasPostPermission = usePostPermission({ community });
+
   const openBottomSheet = () => setIsBottomSheetVisible(true);
 
   const closeBottomSheet = () => setIsBottomSheetVisible(false);
@@ -350,7 +353,7 @@ function CommunityProfileActions({ pageId, communityId, styles }) {
     });
   };
 
-  if (!community?.isJoined) return null;
+  if (!hasPostPermission) return null;
 
   return (
     <Fragment>

--- a/src/v4/component/Avatar/Avatar.tsx
+++ b/src/v4/component/Avatar/Avatar.tsx
@@ -54,7 +54,7 @@ function Avatar({ uri, imageProps, iconProps, userAvatarProps }: AvatarProps) {
         {...imageProps}
         onError={() => setImageError(true)}
       />
-      {userAvatarProps.roles && isModerator(userAvatarProps.roles) && (
+      {userAvatarProps?.roles && isModerator(userAvatarProps?.roles) && (
         <ModeratorBadge style={styles.moderatorBadge} />
       )}
     </TouchableOpacity>
@@ -62,7 +62,7 @@ function Avatar({ uri, imageProps, iconProps, userAvatarProps }: AvatarProps) {
     <SvgXml {...iconProps} />
   ) : (
     <TouchableOpacity
-      style={[styles.defaultUserAvatar, userAvatarProps.style]}
+      style={[styles.defaultUserAvatar, userAvatarProps?.style]}
       activeOpacity={0.7}
       onPress={() => {
         if (userAvatarProps?.shouldRedirectToUserProfile) {
@@ -75,7 +75,7 @@ function Avatar({ uri, imageProps, iconProps, userAvatarProps }: AvatarProps) {
       <Typography.Body style={styles.firstChar}>
         {userAvatarProps.userName?.trim()?.charAt(0).toUpperCase()}
       </Typography.Body>
-      {userAvatarProps.roles && isModerator(userAvatarProps.roles) && (
+      {userAvatarProps?.roles && isModerator(userAvatarProps.roles) && (
         <ModeratorBadge style={styles.moderatorBadge} />
       )}
     </TouchableOpacity>

--- a/src/v4/component/Avatar/Avatar.tsx
+++ b/src/v4/component/Avatar/Avatar.tsx
@@ -54,6 +54,9 @@ function Avatar({ uri, imageProps, iconProps, userAvatarProps }: AvatarProps) {
         {...imageProps}
         onError={() => setImageError(true)}
       />
+      {userAvatarProps.roles && isModerator(userAvatarProps.roles) && (
+        <ModeratorBadge style={styles.moderatorBadge} />
+      )}
     </TouchableOpacity>
   ) : iconProps ? (
     <SvgXml {...iconProps} />

--- a/src/v4/component/TargetSelectionPage/TargetSelectionPage.tsx
+++ b/src/v4/component/TargetSelectionPage/TargetSelectionPage.tsx
@@ -19,6 +19,8 @@ import { useStyles } from './styles';
 import { Illustration } from '../../../v4/PublicApi/Components/AmityEmptyNewsFeedComponent/Elements';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { CommunityPostSettings } from '@amityco/ts-sdk-react-native';
+import { usePostPermission } from '../../../v4/hook/usePostPermission';
 
 export type FeedParams = {
   targetId: string;
@@ -76,7 +78,7 @@ const TargetSelectionPage = ({
   });
 
   const renderItem = ({ item }: { item: Amity.Community }) => {
-    return (
+    const target = (
       <TargetItem
         key={item.communityId}
         displayName={item.displayName}
@@ -88,12 +90,20 @@ const TargetSelectionPage = ({
             targetName: item.displayName,
             targetType: 'community',
             community: item,
+            postSetting: item.postSetting,
+            isPublic: item.isPublic,
           })
         }
         avatarElementId={ElementID.community_avatar}
         avatarFileId={item.avatarFileId}
       />
     );
+
+    if (item?.postSetting === CommunityPostSettings.ONLY_ADMIN_CAN_POST) {
+      return <AdminOnlyCommunity community={item}>{target}</AdminOnlyCommunity>;
+    }
+
+    return target;
   };
 
   return (
@@ -166,3 +176,14 @@ const TargetSelectionPage = ({
 };
 
 export default React.memo(TargetSelectionPage);
+
+type AdminOnlyCommunityProps = {
+  community: Amity.Community;
+  children: React.ReactNode;
+};
+
+function AdminOnlyCommunity({ community, children }: AdminOnlyCommunityProps) {
+  const hasPostPermission = usePostPermission({ community });
+
+  return hasPostPermission ? children : null;
+}

--- a/src/v4/features/community/Membership/components/MemberItem/MemberItem.tsx
+++ b/src/v4/features/community/Membership/components/MemberItem/MemberItem.tsx
@@ -221,6 +221,7 @@ function MemberItem({ member, communityId, refreshMembers }: MemberItemProps) {
           uri={member.user?.avatarCustomUrl}
           roles={member.roles}
           userName={member.user?.displayName ?? member.user?.userId}
+          userId={member.userId}
         />
         <Typography.BodyBold
           style={styles.userName}

--- a/src/v4/hook/usePostPermission.ts
+++ b/src/v4/hook/usePostPermission.ts
@@ -1,0 +1,46 @@
+import {
+  CommunityPostSettings,
+  CommunityRepository,
+} from '@amityco/ts-sdk-react-native';
+import { useEffect, useState } from 'react';
+import useAuth from '../../hooks/useAuth';
+import { isModerator } from '../utils/permissions';
+
+type UsePostPermissionParams = {
+  community?: Amity.Community;
+};
+
+export function usePostPermission({ community }: UsePostPermissionParams) {
+  const { client } = useAuth();
+  const [hasPostPermission, setHasPostPermission] = useState(false);
+
+  const isOnlyAdminCanPost =
+    community?.postSetting === CommunityPostSettings.ONLY_ADMIN_CAN_POST;
+
+  useEffect(() => {
+    if (!community?.communityId || !client?.userId) return;
+
+    CommunityRepository.Membership.searchMembers(
+      {
+        communityId: community.communityId,
+        search: client.userId,
+        limit: 1,
+        memberships: ['member'],
+        includeDeleted: false,
+      },
+      ({ data }) => {
+        const userRoles = data[0]?.roles ?? [];
+        setHasPostPermission(
+          isOnlyAdminCanPost ? isModerator(userRoles) : !!community?.isJoined
+        );
+      }
+    );
+  }, [
+    community?.communityId,
+    client?.userId,
+    isOnlyAdminCanPost,
+    community?.isJoined,
+  ]);
+
+  return hasPostPermission;
+}


### PR DESCRIPTION
**Jira ticket :**

- https://socialplus.atlassian.net/browse/PDT-1315

**Description :**

**Permission Handling Improvements:**

* Added a new `usePostPermission` hook to encapsulate logic for determining whether the current user can post in a community, considering admin-only posting settings and membership status. (`src/v4/hook/usePostPermission.ts`)
* Updated `CommunityProfileActions` to use the new `usePostPermission` hook, replacing the previous `isJoined` check for rendering actions, ensuring only users with posting permissions see relevant UI elements. (`src/v4/PublicApi/Pages/AmityCommunityProfilePage/AmityCommunityProfilePage.tsx`) 

**Moderator Visibility Enhancements:**

* Modified the `Avatar` component to display a `ModeratorBadge` when the user has moderator roles, improving moderator visibility in the UI. (`src/v4/component/Avatar/Avatar.tsx`)
* Updated the `MemberItem` component to pass `userId` to the `Avatar` component, supporting improved identification and rendering logic. (`src/v4/features/community/Membership/components/MemberItem/MemberItem.tsx`)

**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

https://github.com/user-attachments/assets/e56b0f34-3954-415f-802d-dba9851d22b8

**Note (optional) :**
