### PR TITLE
feat: PDT-802 - update ci/cd

### DIFF
--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -1,19 +1,46 @@
 name: Production release pipeline
 
 on:
-  push:
-    tags:
-      - 'v*'
+  workflow_dispatch:
+    inputs:
+      release_as:
+        type: choice
+        description: 'release as'
+        required: false
+        options:
+          - none
+          - major
+          - minor
+          - patch
+          - stable
+      pre-release:
+        type: choice
+        description: 'prerelease'
+        required: false
+        options:
+          - none
+          - RC
+          - alpha
+          - beta
+
+env:
+  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
 jobs:
   publish:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - name: git checkout
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
+
+      - name: configure committer
+        run: |
+          git config user.name "bmo-amity-bot"
+          git config user.email "developers@amity.co"
 
       - uses: actions/setup-node@v3
         with:
@@ -24,6 +51,41 @@ jobs:
 
       - name: install deps
         run: yarn install --immutable
+
+      - name: increase version (patch)
+        run: npx standard-version --yes --release-as patch
+        if: github.event.inputs.release_as == 'patch' && github.event.inputs.pre-release == 'none'
+
+      - name: increase version (patch) (pre-release)
+        run: npx standard-version --yes --release-as patch --prerelease ${{ github.event.inputs.pre-release }}
+        if: github.event.inputs.release_as == 'patch' && github.event.inputs.pre-release != 'none'
+
+      - name: increase version (minor)
+        run: npx standard-version --yes --release-as minor
+        if: github.event.inputs.release_as == 'minor' && github.event.inputs.pre-release == 'none'
+
+      - name: increase version (minor) (pre-release)
+        run: npx standard-version --yes --release-as minor --prerelease ${{ github.event.inputs.pre-release }}
+        if: github.event.inputs.release_as == 'minor' && github.event.inputs.pre-release != 'none'
+
+      - name: increase version (major)
+        run: npx standard-version --yes --release-as major
+        if: github.event.inputs.release_as == 'major' && github.event.inputs.pre-release == 'none'
+
+      - name: increase version (major) (pre-release)
+        run: npx standard-version --yes --release-as major --prerelease ${{ github.event.inputs.pre-release }}
+        if: github.event.inputs.release_as == 'major' && github.event.inputs.pre-release != 'none'
+
+      - name: increase version (pre-release)
+        run: npx standard-version --yes --prerelease ${{ github.event.inputs.pre-release }}
+        if: github.event.inputs.release_as == 'none' && github.event.inputs.pre-release != 'none'
+
+      - name: Release stable version
+        run: |
+          current_version=$(node -p "require('./package.json').version")
+          stable_version=$(echo $current_version | sed 's/-.*//')
+          npx standard-version --yes --release-as $stable_version
+        if: github.event.inputs.release_as == 'stable'
 
       - name: build library
         run: yarn prepack
@@ -40,3 +102,6 @@ jobs:
         run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: push version
+        run: git push --follow-tags

--- a/package.json
+++ b/package.json
@@ -248,7 +248,7 @@
     "react-native-paper": "^5.10.6",
     "react-native-progress": "^5.0.0",
     "react-native-radio-buttons-group": "^3.0.2",
-    "react-redux": "^8.1.3",
+    "react-redux": "^9.1.2",
     "redux": "^4.2.1",
     "zod": "^4.1.1"
   },

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "@livekit/react-native": "^2.9.6",
     "@livekit/react-native-webrtc": "^137.0.2",
     "@react-native-async-storage/async-storage": "^1.19.3",
+    "@react-native-clipboard/clipboard": "^1.16.3",
     "@react-native-community/netinfo": "^11.3.1",
     "@react-native-firebase/app": "^20.1.0",
     "@react-native-firebase/messaging": "^20.1.0",
@@ -144,8 +145,7 @@
     "react-native-screens": "^4.18.0",
     "react-native-svg": "^15.15.1",
     "react-native-video": "^6.18.0",
-    "react-native-vision-camera": "^4.7.3",
-    "@react-native-clipboard/clipboard": "^1.16.3"
+    "react-native-vision-camera": "^4.7.3"
   },
   "engines": {
     "node": ">=20"
@@ -235,6 +235,7 @@
     "dayjs": "^1.11.10",
     "html-entities": "^2.5.2",
     "i18next": "22.4.10",
+    "mime": "^4.1.0",
     "polished": "^4.3.1",
     "react-content-loader": "^6.2.1",
     "react-hook-form": "^7.49.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amityco/react-native-social-uikit",
-  "version": "4.0.0-RC20",
+  "version": "4.0.0-RC.20",
   "description": "Social UIKit",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,5 +1,7 @@
-
 {
   "extends": "./tsconfig",
+  "compilerOptions": {
+    "rootDir": "src"
+  },
   "exclude": ["example"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1427,7 +1427,7 @@
     "@babel/plugin-transform-modules-commonjs" "^7.27.1"
     "@babel/plugin-transform-typescript" "^7.27.1"
 
-"@babel/runtime@^7.12.1", "@babel/runtime@^7.17.8", "@babel/runtime@^7.20.6", "@babel/runtime@^7.25.0", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.17.8", "@babel/runtime@^7.20.6", "@babel/runtime@^7.25.0", "@babel/runtime@^7.9.2":
   version "7.27.6"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.27.6.tgz#ec4070a04d76bae8ddbb10770ba55714a417b7c6"
   integrity sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==
@@ -1450,20 +1450,7 @@
     "@babel/parser" "^7.28.6"
     "@babel/types" "^7.28.6"
 
-"@babel/traverse--for-generate-function-map@npm:@babel/traverse@^7.25.3":
-  version "7.27.4"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.27.4.tgz#b0045ac7023c8472c3d35effd7cc9ebd638da6ea"
-  integrity sha512-oNcu2QbHqts9BtOWJosOVJapWjBDSxGCpFvikNR5TGDYDQf3JwpIoMzIKrvfoti93cLfPJEG4tH9SPVeyCGgdA==
-  dependencies:
-    "@babel/code-frame" "^7.27.1"
-    "@babel/generator" "^7.27.3"
-    "@babel/parser" "^7.27.4"
-    "@babel/template" "^7.27.2"
-    "@babel/types" "^7.27.3"
-    debug "^4.3.1"
-    globals "^11.1.0"
-
-"@babel/traverse@^7.25.3", "@babel/traverse@^7.27.1", "@babel/traverse@^7.27.3", "@babel/traverse@^7.27.4":
+"@babel/traverse--for-generate-function-map@npm:@babel/traverse@^7.25.3", "@babel/traverse@^7.25.3", "@babel/traverse@^7.27.1", "@babel/traverse@^7.27.3", "@babel/traverse@^7.27.4":
   version "7.27.4"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.27.4.tgz#b0045ac7023c8472c3d35effd7cc9ebd638da6ea"
   integrity sha512-oNcu2QbHqts9BtOWJosOVJapWjBDSxGCpFvikNR5TGDYDQf3JwpIoMzIKrvfoti93cLfPJEG4tH9SPVeyCGgdA==
@@ -3297,14 +3284,6 @@
   resolved "https://registry.yarnpkg.com/@types/hammerjs/-/hammerjs-2.0.46.tgz#381daaca1360ff8a7c8dff63f32e69745b9fb1e1"
   integrity sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==
 
-"@types/hoist-non-react-statics@^3.3.1":
-  version "3.3.6"
-  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.6.tgz#6bba74383cdab98e8db4e20ce5b4a6b98caed010"
-  integrity sha512-lPByRJUer/iN/xa4qpyL0qmL11DqNW81iU/IG1S3uvRUq4oKagz8VCxZjiWkumgt66YT3vOdDgZ0o32sGKtCEw==
-  dependencies:
-    "@types/react" "*"
-    hoist-non-react-statics "^3.3.0"
-
 "@types/http-cache-semantics@^4.0.2":
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz#b979ebad3919799c979b17c72621c0bc0a31c6c4"
@@ -3420,10 +3399,10 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.3.tgz#6209321eb2c1712a7e7466422b8cb1fc0d9dd5d8"
   integrity sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==
 
-"@types/use-sync-external-store@^0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz#b6725d5f4af24ace33b36fafd295136e75509f43"
-  integrity sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==
+"@types/use-sync-external-store@^0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz#60be8d21baab8c305132eb9cb912ed497852aadc"
+  integrity sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==
 
 "@types/yargs-parser@*":
   version "21.0.3"
@@ -6633,7 +6612,7 @@ hls.js@^1.4.10:
   resolved "https://registry.yarnpkg.com/hls.js/-/hls.js-1.6.15.tgz#9ce13080d143a9bc9b903fb43f081e335b8321e5"
   integrity sha512-E3a5VwgXimGHwpRGV+WxRTKeSp2DW5DI5MWv34ulL3t5UNmyJWCQ1KmLEHbYzcfThfXG8amBL+fCYPneGHC4VA==
 
-hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
+hoist-non-react-statics@^3.3.0:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -10090,17 +10069,13 @@ react-native@0.82.1:
     ws "^6.2.3"
     yargs "^17.6.2"
 
-react-redux@^8.1.3:
-  version "8.1.3"
-  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-8.1.3.tgz#4fdc0462d0acb59af29a13c27ffef6f49ab4df46"
-  integrity sha512-n0ZrutD7DaX/j9VscF+uTALI3oUPa/pO4Z3soOBIjuRn/FzVu6aehhysxZCLi6y7duMf52WNZGMl7CtuK5EnRw==
+react-redux@^9.1.2:
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-9.2.0.tgz#96c3ab23fb9a3af2cb4654be4b51c989e32366f5"
+  integrity sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==
   dependencies:
-    "@babel/runtime" "^7.12.1"
-    "@types/hoist-non-react-statics" "^3.3.1"
-    "@types/use-sync-external-store" "^0.0.3"
-    hoist-non-react-statics "^3.3.2"
-    react-is "^18.0.0"
-    use-sync-external-store "^1.0.0"
+    "@types/use-sync-external-store" "^0.0.6"
+    use-sync-external-store "^1.4.0"
 
 react-refresh@^0.14.0:
   version "0.14.2"
@@ -11661,7 +11636,12 @@ use-latest-callback@^0.2.3, use-latest-callback@^0.2.4:
   resolved "https://registry.yarnpkg.com/use-latest-callback/-/use-latest-callback-0.2.4.tgz#35c0f028f85a3f4cf025b06011110e87cc18f57e"
   integrity sha512-LS2s2n1usUUnDq4oVh1ca6JFX9uSqUncTfAm44WMg0v6TxL7POUTk1B044NH8TeLkFbNajIsgDHcgNpNzZucdg==
 
-use-sync-external-store@^1.0.0, use-sync-external-store@^1.5.0:
+use-sync-external-store@^1.4.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz#b174bfa65cb2b526732d9f2ac0a408027876f32d"
+  integrity sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==
+
+use-sync-external-store@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz#55122e2a3edd2a6c106174c27485e0fd59bcfca0"
   integrity sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -8773,6 +8773,11 @@ mime@3.0.0:
   resolved "https://registry.yarnpkg.com/mime/-/mime-3.0.0.tgz#b374550dca3a0c18443b0c950a6a58f1931cf7a7"
   integrity sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==
 
+mime@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-4.1.0.tgz#ec55df7aa21832a36d44f0bbee5c04639b27802f"
+  integrity sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw==
+
 mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"


### PR DESCRIPTION
**Jira ticket :**

https://socialplus.atlassian.net/browse/PDT-802

**Description :**

This pull request updates the release pipeline and dependency management for the project, focusing on making releases more flexible and improving package configuration. The main changes include converting the production release workflow to a manual trigger with detailed versioning options, updating and adding dependencies, and fixing a version formatting issue.

**Release pipeline improvements:**

* The `.github/workflows/production.yaml` workflow is now triggered manually (`workflow_dispatch`) with inputs for release type and pre-release identifiers, allowing more control over release versions.
* Automated version bumping steps using `standard-version` have been added for patch, minor, major, pre-release, and stable releases, determined by workflow inputs.
* After publishing, the workflow now pushes version tags to the repository to ensure version history is consistent.

**Dependency and configuration updates:**

* The `@react-native-clipboard/clipboard` dependency is moved from the main dependencies list to the correct place in `package.json`, and the `mime` package is added. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R126) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L147-R148) [[3]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R238)
* The `react-redux` dependency is updated from version `8.1.3` to `9.1.2`.
* The `version` field in `package.json` is corrected from `4.0.0-RC20` to `4.0.0-RC.20` for proper semantic versioning.

**Build configuration:**

* The `tsconfig.build.json` now explicitly sets the `rootDir` to `src` for clearer TypeScript build configuration.

**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

<img width="1118" height="383" alt="Screenshot 2569-04-30 at 10 18 31" src="https://github.com/user-attachments/assets/4b777713-37ca-4801-a471-a8432c215f2a" />

<img width="1105" height="379" alt="Screenshot 2569-04-30 at 10 18 55" src="https://github.com/user-attachments/assets/1ebd44ab-767d-4731-a071-e98ef31e0086" />


**Note (optional) :**
