### PR TITLE
fix: PDT-2615 - cannot search community + cannot click bottomsheet on android

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - amity-react-native-social-ui-kit (4.0.0-RC20):
+  - amity-react-native-social-ui-kit (4.0.0-RC.20):
     - boost
     - DoubleConversion
     - fast_float
@@ -3288,7 +3288,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  amity-react-native-social-ui-kit: 8b35785f1e823c70f2a381941ecf3211f5aa2ead
+  amity-react-native-social-ui-kit: c7d69deb04cc36783d46aecba2eeda02401ac26d
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   BVLinearGradient: cb006ba232a1f3e4f341bb62c42d1098c284da70
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb

--- a/src/social/components/BottomSheetComponent/BottomSheetComponent.tsx
+++ b/src/social/components/BottomSheetComponent/BottomSheetComponent.tsx
@@ -21,6 +21,7 @@ const BottomSheetComponent = () => {
       closeOnBackdropPress
       style={styles.container}
       onClose={closeBottomSheet}
+      disableBodyPanning
     >
       {content}
     </BottomSheet>

--- a/src/social/features/feed/components/CommunityCategories/CommunityCategories.tsx
+++ b/src/social/features/feed/components/CommunityCategories/CommunityCategories.tsx
@@ -4,7 +4,7 @@ import { useStyles } from './styles';
 import { ComponentID, PageID } from '../../../../enums';
 
 type CommunityCategoriesProps = ViewProps & {
-  categories: Amity.Category[];
+  categories?: Amity.Category[];
   pageId?: PageID;
   componentId?: ComponentID;
   allVisible?: boolean;
@@ -13,7 +13,7 @@ type CommunityCategoriesProps = ViewProps & {
 const MAX_VISIBLE_CATEGORIES = 2;
 
 export function CommunityCategories({
-  categories,
+  categories = [],
   allVisible,
   ...props
 }: CommunityCategoriesProps) {


### PR DESCRIPTION
**Jira ticket :**

https://socialplus.atlassian.net/browse/PDT-2615

**Description :**

This pull request introduces a small set of changes to improve the flexibility and user experience of the community categories and bottom sheet components. The main updates include making the `categories` prop optional with a default value and disabling body panning in the bottom sheet.

**Component flexibility improvements:**

* Made the `categories` prop in `CommunityCategories` optional (`categories?: Amity.Category[]`) and set a default value of an empty array to prevent errors when the prop is not provided. [[1]](diffhunk://#diff-a09e5ae841cc5d21fa888333ec7e39f75ac6c7347715932b3c01871dd58586eeL7-R7) [[2]](diffhunk://#diff-a09e5ae841cc5d21fa888333ec7e39f75ac6c7347715932b3c01871dd58586eeL16-R16)

**User experience enhancements:**

* Disabled body panning in `BottomSheetComponent` by adding the `disableBodyPanning` prop, which can help prevent unintended scrolling or movement when the bottom sheet is open.

**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**


https://github.com/user-attachments/assets/53279381-f3f9-437b-b708-f9594873b578


https://github.com/user-attachments/assets/716e38b9-728a-4ab5-b609-b709b3a0bb04



**Note (optional) :**
