### PR TITLE
fix: PDT-2725 - duplicate key and slice undefined

### DIFF
--- a/src/redux/slices/globalfeedSlice.ts
+++ b/src/redux/slices/globalfeedSlice.ts
@@ -21,23 +21,28 @@ const globalFeedSlice = createSlice({
   initialState,
   reducers: {
     setNewGlobalFeed: (state, action: PayloadAction<Amity.Post<any>[]>) => {
-      state.postList = [...action.payload];
+      const seen = new Set<string>();
+      state.postList = action.payload.filter((post) => {
+        if (seen.has(post.postId)) return false;
+        seen.add(post.postId);
+        return true;
+      });
     },
     updateGlobalFeed: (state, action: PayloadAction<Amity.Post<any>[]>) => {
-      const getUniqueArrayById = (arr: (Amity.Post<any> | Amity.Ad)[]) => {
-        const uniqueIds = new Set(
-          state.postList.map((post) =>
-            isAmityAd(post) ? post.adId : post.postId
-          )
-        );
-        return arr.filter(
-          (post) => !uniqueIds.has(isAmityAd(post) ? post.adId : post.postId)
-        );
-      };
-      state.postList = [
-        ...state.postList,
-        ...getUniqueArrayById(action.payload),
-      ];
+      const uniqueIds = new Set(
+        state.postList.map((post) =>
+          isAmityAd(post) ? post.adId : post.postId
+        )
+      );
+      const newUnique: (Amity.Post<any> | Amity.Ad)[] = [];
+      for (const post of action.payload) {
+        const id = isAmityAd(post) ? post.adId : post.postId;
+        if (!uniqueIds.has(id)) {
+          uniqueIds.add(id);
+          newUnique.push(post);
+        }
+      }
+      state.postList = [...state.postList, ...newUnique];
     },
     setPaginationData: (
       state,
@@ -46,7 +51,12 @@ const globalFeedSlice = createSlice({
       state.paginationData = action.payload;
     },
     addPostToGlobalFeed: (state, action: PayloadAction<Amity.Post<any>>) => {
-      state.postList = [action.payload, ...state.postList];
+      const alreadyExists = state.postList.some(
+        (item) => !isAmityAd(item) && item.postId === action.payload.postId
+      );
+      if (!alreadyExists) {
+        state.postList = [action.payload, ...state.postList];
+      }
     },
     updateByPostId: (
       state,

--- a/src/v4/PublicApi/Components/AmityGlobalFeedComponent/AmityGlobalFeedComponent.tsx
+++ b/src/v4/PublicApi/Components/AmityGlobalFeedComponent/AmityGlobalFeedComponent.tsx
@@ -106,8 +106,10 @@ const AmityGlobalFeedComponent: FC<AmityGlobalFeedComponentType> = ({
           </>
         );
       }}
-      keyExtractor={(item) =>
-        isAmityAd(item) ? item.adId.toString() : item.postId.toString()
+      keyExtractor={(item, index) =>
+        isAmityAd(item)
+          ? item.adId.toString() + '_' + index
+          : item.postId.toString() + '_' + index
       }
       onEndReachedThreshold={0.5}
       onEndReached={handleLoadMore}

--- a/src/v4/component/CommunitySearchResult/CommunitySearchResult.tsx
+++ b/src/v4/component/CommunitySearchResult/CommunitySearchResult.tsx
@@ -108,7 +108,9 @@ const CommunitySearchResult: FC<CommunitySearchResultProps> = ({
             />
           </Pressable>
         )}
-        keyExtractor={(item, index) => item.communityId + index}
+        keyExtractor={(item, index) =>
+          (item.communityId ?? index).toString() + '_' + index
+        }
         onEndReachedThreshold={0.5}
         style={styles.list}
         contentContainerStyle={styles.listContent}

--- a/src/v4/features/feed/components/CommunityCategories/CommunityCategories.tsx
+++ b/src/v4/features/feed/components/CommunityCategories/CommunityCategories.tsx
@@ -14,7 +14,7 @@ type CommunityCategoriesProps = ViewProps & {
 const MAX_VISIBLE_CATEGORIES = 2;
 
 export function CommunityCategories({
-  categories,
+  categories = [],
   allVisible,
   ...props
 }: CommunityCategoriesProps) {

--- a/src/v4/hook/usePaginator.ts
+++ b/src/v4/hook/usePaginator.ts
@@ -140,7 +140,13 @@ export const usePaginatorCore = <T>({
         .slice(0, topIndex)
         .map((item) => [item]);
 
-      const prevItems = [...newestItems, ...prevItemWithAds];
+      const prevItemWithAdsIds = new Set(
+        prevItemWithAds.map((item) => getItemId(item[0]))
+      );
+      const dedupedNewestItems = newestItems.filter(
+        (item) => !prevItemWithAdsIds.has(getItemId(item[0]))
+      );
+      const prevItems = [...dedupedNewestItems, ...prevItemWithAds];
 
       // filteredNewItems is the newest items in the next page that are not in prevItems
       const filteredNewItems = filterNewItems(newItems, topIndex, prevItems);
@@ -172,14 +178,24 @@ export const usePaginatorCore = <T>({
 
       const newItemsWithAds = [...prevItems, ...suffixItems];
 
-      updateItemWithAds(newItemsWithAds);
+      const seenPostIds = new Set<string>();
+      const dedupedItemsWithAds = newItemsWithAds.filter((tuple) => {
+        const id = getItemId(tuple[0]);
+        if (seenPostIds.has(id)) return false;
+        seenPostIds.add(id);
+        return true;
+      });
 
-      if (newItemsWithAds.length === 0) {
+      updateItemWithAds(dedupedItemsWithAds);
+
+      if (dedupedItemsWithAds.length === 0) {
         setCurrentAdIndex(0);
         setCurrentIndex(0);
       }
 
-      const result = newItemsWithAds.flatMap((item) => item).filter(Boolean);
+      const result = dedupedItemsWithAds
+        .flatMap((item) => item)
+        .filter(Boolean);
       return result;
     } else if (frequency?.type === 'time-window') {
       const newItemIds = new Set(newItems.map((item) => getItemId(item)));
@@ -190,7 +206,13 @@ export const usePaginatorCore = <T>({
         .slice(0, topIndex)
         .map((item) => [item]);
 
-      const prevItems = [...newestItems, ...prevItemWithAds];
+      const twPrevItemWithAdsIds = new Set(
+        prevItemWithAds.map((item) => getItemId(item[0]))
+      );
+      const twDedupedNewestItems = newestItems.filter(
+        (item) => !twPrevItemWithAdsIds.has(getItemId(item[0]))
+      );
+      const prevItems = [...twDedupedNewestItems, ...prevItemWithAds];
       const filteredNewItems = filterNewItems(newItems, topIndex, prevItems);
       const suffixItems: Array<ItemWithAd<T>> = filteredNewItems.map(
         (newItem, index) => {
@@ -211,11 +233,21 @@ export const usePaginatorCore = <T>({
 
       setHasAppenedFirstRoundAds(true);
 
-      const newItemsWithAds = [...prevItems, ...suffixItems];
+      const seenTwPostIds = new Set<string>();
+      const dedupedTwItemsWithAds = [...prevItems, ...suffixItems].filter(
+        (tuple) => {
+          const id = getItemId(tuple[0]);
+          if (seenTwPostIds.has(id)) return false;
+          seenTwPostIds.add(id);
+          return true;
+        }
+      );
 
-      updateItemWithAds(newItemsWithAds);
+      updateItemWithAds(dedupedTwItemsWithAds);
 
-      const result = newItemsWithAds.flatMap((item) => item).filter(Boolean);
+      const result = dedupedTwItemsWithAds
+        .flatMap((item) => item)
+        .filter(Boolean);
       return result;
     }
     return newItems;


### PR DESCRIPTION
**Jira ticket :**
https://socialplus.atlassian.net/browse/PDT-2725

**Description :**
This pull request focuses on improving the handling of duplicate posts and ads in the global feed, search results, and paginated data. The main changes ensure that duplicate entries are removed or prevented from being added, which helps maintain data integrity and improves the user experience. Additionally, key extraction logic for lists has been refined to further prevent rendering issues caused by duplicate keys.

**Deduplication and Data Integrity Improvements:**

* The `setNewGlobalFeed` and `updateGlobalFeed` reducers in `globalfeedSlice.ts` now filter out duplicate posts and ads based on their unique identifiers, preventing duplicates in the global feed.
* The `addPostToGlobalFeed` reducer now checks for existing posts before adding a new one, ensuring no duplicates are prepended to the feed.
* The `usePaginatorCore` hook in `usePaginator.ts` has been updated to deduplicate posts and ads when paginating, both for regular and time-window ad frequency modes, ensuring that no duplicate items are inserted during pagination. [[1]](diffhunk://#diff-c81a12147a0dacb714f91a3385145924665118147b67d779d4d26f172dedc328L143-R149) [[2]](diffhunk://#diff-c81a12147a0dacb714f91a3385145924665118147b67d779d4d26f172dedc328L175-R198) [[3]](diffhunk://#diff-c81a12147a0dacb714f91a3385145924665118147b67d779d4d26f172dedc328L193-R215) [[4]](diffhunk://#diff-c81a12147a0dacb714f91a3385145924665118147b67d779d4d26f172dedc328L214-R250)

**Key Extraction Logic Updates:**

* The `keyExtractor` functions in `AmityGlobalFeedComponent.tsx` and `CommunitySearchResult.tsx` have been updated to generate more unique keys by including the item index, reducing the risk of rendering issues due to duplicate keys. [[1]](diffhunk://#diff-8427cc0a35b7a87ea21355f2740c987af681b3a45a72f27454c7788758f9f968L109-R112) [[2]](diffhunk://#diff-6add1baf22d87dd8e87d68adf8cb3b3822ed15195a821d3b6e76203a7eecce0bL111-R113)

**Default Prop Handling:**

* The `categories` prop in `CommunityCategories.tsx` now defaults to an empty array if not provided, preventing potential runtime errors.
**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

https://github.com/user-attachments/assets/005fafa9-cea2-43b0-a866-d02b90476c88


https://github.com/user-attachments/assets/282bddc2-50dc-4e40-805d-7d45cd96a389


**Note (optional) :**


