### PR TITLE
fix: PDT-2814 - permission to post story

### DIFF
--- a/src/social/screens/CommunityProfile/index.tsx
+++ b/src/social/screens/CommunityProfile/index.tsx
@@ -359,7 +359,7 @@ function CommunityProfileActions({ pageId, communityId, styles }) {
     });
   };
 
-  if (!hasPostPermission) return null;
+  if (!hasPostPermission && !hasStoryPermission) return null;
 
   return (
     <Fragment>
@@ -374,17 +374,19 @@ function CommunityProfileActions({ pageId, communityId, styles }) {
         <Pressable onPress={closeBottomSheet} style={styles.modalOverlay}>
           <Animated.View style={styles.modalContent}>
             <View style={styles.dragHandle} />
-            <TouchableOpacity
-              onPress={handleCreatePost}
-              style={styles.bottomSheetOption}
-            >
-              <SvgXml
-                xml={post({ fill: colors.base })}
-                width={24}
-                height={24}
-              />
-              <Text style={styles.bottomSheetOptionText}>Post</Text>
-            </TouchableOpacity>
+            {hasPostPermission && (
+              <TouchableOpacity
+                onPress={handleCreatePost}
+                style={styles.bottomSheetOption}
+              >
+                <SvgXml
+                  xml={post({ fill: colors.base })}
+                  width={24}
+                  height={24}
+                />
+                <Text style={styles.bottomSheetOptionText}>Post</Text>
+              </TouchableOpacity>
+            )}
             {hasStoryPermission && (
               <TouchableOpacity
                 onPress={handleCreateStory}
@@ -399,26 +401,34 @@ function CommunityProfileActions({ pageId, communityId, styles }) {
                 <Text style={styles.bottomSheetOptionText}>Story</Text>
               </TouchableOpacity>
             )}
-
-            <TouchableOpacity
-              onPress={handleCreatePoll}
-              style={styles.bottomSheetOption}
-            >
-              <SvgXml width={24} height={24} xml={poll()} color={colors.base} />
-              <Text style={styles.bottomSheetOptionText}>Poll</Text>
-            </TouchableOpacity>
-            <TouchableOpacity
-              onPress={handleCreateLivestream}
-              style={styles.bottomSheetOption}
-            >
-              <SvgXml
-                width={24}
-                height={24}
-                xml={livestream()}
-                color={colors.base}
-              />
-              <Text style={styles.bottomSheetOptionText}>Livestream</Text>
-            </TouchableOpacity>
+            {hasPostPermission && (
+              <TouchableOpacity
+                onPress={handleCreatePoll}
+                style={styles.bottomSheetOption}
+              >
+                <SvgXml
+                  width={24}
+                  height={24}
+                  xml={poll()}
+                  color={colors.base}
+                />
+                <Text style={styles.bottomSheetOptionText}>Poll</Text>
+              </TouchableOpacity>
+            )}
+            {hasPostPermission && (
+              <TouchableOpacity
+                onPress={handleCreateLivestream}
+                style={styles.bottomSheetOption}
+              >
+                <SvgXml
+                  width={24}
+                  height={24}
+                  xml={livestream()}
+                  color={colors.base}
+                />
+                <Text style={styles.bottomSheetOptionText}>Livestream</Text>
+              </TouchableOpacity>
+            )}
           </Animated.View>
         </Pressable>
       </Modal>


### PR DESCRIPTION
**Jira ticket :**
https://www.ulta.com/communities/692ddc7dd867a039d29a0af1
**Description :**
This pull request updates the `CommunityProfileActions` component to improve permission checks and ensure that only users with the appropriate permissions see the correct action options. The main focus is on making the UI accurately reflect whether the user can create posts, stories, polls, or livestreams.

Permission handling improvements:

* The component now checks both `hasPostPermission` and `hasStoryPermission` before rendering any actions, ensuring that users without either permission see no options.
* Each action button (Post, Poll, Livestream) is now individually wrapped in a check for `hasPostPermission`, so only users with post permissions see those options. [[1]](diffhunk://#diff-81b4d5957ead5671db11ce0ca63856548f62ba7f98db2bc92d71ffd9cd7c9fcfR377) [[2]](diffhunk://#diff-81b4d5957ead5671db11ce0ca63856548f62ba7f98db2bc92d71ffd9cd7c9fcfL402-R418) [[3]](diffhunk://#diff-81b4d5957ead5671db11ce0ca63856548f62ba7f98db2bc92d71ffd9cd7c9fcfR431)
* The Story action button is shown only if the user has `hasStoryPermission`.

UI code improvements:

* The SVG rendering for the Poll action has been reformatted for better readability.
**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**



https://github.com/user-attachments/assets/fe09f87b-e06e-4337-9f34-b7f8716e878c

**Note (optional) :**