### PR TITLE
fix: PDT-2668 - render new post on feed

### DIFF
--- a/src/social/features/feed/components/NewsFeed/NewsFeed.tsx
+++ b/src/social/features/feed/components/NewsFeed/NewsFeed.tsx
@@ -29,7 +29,7 @@ const AmityNewsFeedComponent: FC<AmityNewsFeedComponentType> = ({
 
   if (isExcluded) return null;
 
-  if (loading || (globalFeedPosts?.length > 0 && !itemWithAds?.length))
+  if (loading || (globalFeedPosts?.length > 0 && !itemWithAds))
     return <NewsFeedLoadingComponent />;
 
   if (!loading && !globalFeedPosts?.length)


### PR DESCRIPTION
**Jira ticket :**
https://socialplus.atlassian.net/browse/PDT-2668

**Description :**
This pull request makes a small update to the loading logic in the `AmityNewsFeedComponent`. The change ensures that the loading component is shown more consistently by simplifying the condition that checks for `itemWithAds`.

- Improved loading state handling:
  * [`src/social/features/feed/components/NewsFeed/NewsFeed.tsx`](diffhunk://#diff-f4e002d83fff6e2de0320e676f7a6088a04ee0b344fb6004a686aee697bf7657L32-R32): Updated the conditional check to display `NewsFeedLoadingComponent` when `itemWithAds` is falsy, instead of only when it is an empty array.
**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

https://github.com/user-attachments/assets/87e08e34-d1d0-4bc9-946c-03aec3f057bc


**Note (optional) :**
