### PR TITLE
fix: PDT-2726 - user profile navigation

### DIFF
--- a/src/social/features/community/Membership/components/MemberItem/MemberItem.tsx
+++ b/src/social/features/community/Membership/components/MemberItem/MemberItem.tsx
@@ -1,5 +1,8 @@
 import { useMemo } from 'react';
-import { View } from 'react-native';
+import { TouchableOpacity, View } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { RootStackParamList } from '../../../../../../core/routes/RouteParamList';
 import Avatar from '../../../../../components/Avatar';
 import { useStyles } from './style';
 import { Typography } from '../../../../../../core/components/Typography/Typography';
@@ -52,6 +55,8 @@ function useMemberItem({
     userId: member.userId,
     enabled: open,
   });
+  const navigation =
+    useNavigation<NativeStackNavigationProp<RootStackParamList>>();
 
   const addModeratorRoles = () => {
     addRoles(
@@ -142,6 +147,10 @@ function useMemberItem({
     [communityId]
   );
 
+  const goToUserProfile = () => {
+    navigation.navigate('UserProfile', { userId: member.userId });
+  };
+
   return {
     styles,
     isCurrentUser,
@@ -156,6 +165,7 @@ function useMemberItem({
     isModeratorUser,
     isCurrentUserModerator,
     isFlaggedByMeLoading,
+    goToUserProfile,
   };
 }
 
@@ -173,6 +183,7 @@ function MemberItem({ member, communityId, refreshMembers }: MemberItemProps) {
     removeMember,
     isModeratorUser,
     isCurrentUserModerator,
+    goToUserProfile,
   } = useMemberItem({
     member,
     communityId,
@@ -181,7 +192,7 @@ function MemberItem({ member, communityId, refreshMembers }: MemberItemProps) {
 
   return (
     <View style={styles.container}>
-      <View style={styles.userContainer}>
+      <TouchableOpacity style={styles.userContainer} onPress={goToUserProfile}>
         <Avatar.User
           imageStyle={styles.userAvatar}
           uri={member.user?.avatarCustomUrl}
@@ -196,7 +207,7 @@ function MemberItem({ member, communityId, refreshMembers }: MemberItemProps) {
         >
           {member?.user.displayName}
         </Typography.BodyBold>
-      </View>
+      </TouchableOpacity>
       {!isCurrentUser && (
         <MenuButton
           onPress={() => {


### PR DESCRIPTION
**Jira ticket :**
https://socialplus.atlassian.net/browse/PDT-2726

**Description :**
This pull request enhances the `MemberItem` component by adding navigation functionality that allows users to tap on a member's profile and navigate directly to their user profile screen. The main changes involve integrating React Navigation and updating the UI to make the member's avatar and name tappable.

**Navigation and UI Enhancements:**

* Added React Navigation dependencies and types, and initialized navigation in the `useMemberItem` hook to enable navigation actions. [[1]](diffhunk://#diff-18568ddf3ea844ac6e533d4288c63a4abf8154b26c752ab15225edb0e7230f0cL2-R5) [[2]](diffhunk://#diff-18568ddf3ea844ac6e533d4288c63a4abf8154b26c752ab15225edb0e7230f0cR58-R59)
* Implemented a `goToUserProfile` function in the `useMemberItem` hook to navigate to the `UserProfile` screen with the selected user's ID. [[1]](diffhunk://#diff-18568ddf3ea844ac6e533d4288c63a4abf8154b26c752ab15225edb0e7230f0cR150-R153) [[2]](diffhunk://#diff-18568ddf3ea844ac6e533d4288c63a4abf8154b26c752ab15225edb0e7230f0cR168)
* Passed the `goToUserProfile` function to the `MemberItem` component and used it as the `onPress` handler for a new `TouchableOpacity` wrapping the user's avatar and display name, making them tappable. [[1]](diffhunk://#diff-18568ddf3ea844ac6e533d4288c63a4abf8154b26c752ab15225edb0e7230f0cR186) [[2]](diffhunk://#diff-18568ddf3ea844ac6e533d4288c63a4abf8154b26c752ab15225edb0e7230f0cL184-R195) [[3]](diffhunk://#diff-18568ddf3ea844ac6e533d4288c63a4abf8154b26c752ab15225edb0e7230f0cL199-R210)
**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

https://github.com/user-attachments/assets/10656479-84c1-4f0e-8e90-63c10856f6dd


**Note (optional) :**
