### PR TITLE
fix: PDT-2792 - avatar size search user

### DIFF
--- a/src/social/components/SearchResultItem/SearchResultItem.tsx
+++ b/src/social/components/SearchResultItem/SearchResultItem.tsx
@@ -113,6 +113,8 @@ const SearchResultItem: FC<SearchResultItemType> = ({
             elementID={ElementID.community_display_name}
             text={item.displayName}
             style={styles.diaplayName}
+            numberOfLines={1}
+            ellipsizeMode="tail"
           />
 
           {showOfficialBadgeIcon && (

--- a/src/social/components/SearchResultItem/styles.ts
+++ b/src/social/components/SearchResultItem/styles.ts
@@ -10,13 +10,14 @@ export const useStyles = (theme: MyMD3Theme) => {
       marginVertical: 8,
     },
     avatar: {
-      width: 64,
-      height: 64,
-      borderRadius: 64,
+      width: 40,
+      height: 40,
+      borderRadius: 40,
     },
     profileInfoContainer: {
       marginLeft: 16,
       justifyContent: 'center',
+      flex: 1,
     },
     category: {
       marginVertical: 2,
@@ -37,8 +38,9 @@ export const useStyles = (theme: MyMD3Theme) => {
       marginVertical: 2,
     },
     rowContainer: {
-      justifyContent: 'center',
+      alignItems: 'center',
       flexDirection: 'row',
+      flex: 1,
     },
     diaplayName: {
       fontWeight: '600',


### PR DESCRIPTION
**Jira ticket :**
https://socialplus.atlassian.net/browse/PDT-2792
**Description :**
This pull request updates the appearance and layout of the `SearchResultItem` component to improve visual consistency and handle long display names gracefully. The main changes focus on resizing the avatar, refining the layout for better alignment and flexibility, and ensuring display names are truncated if too long.

**UI and Layout Improvements:**

* Reduced the avatar size from 64x64 to 40x40 pixels and adjusted the border radius accordingly in `styles.ts` for a more compact look.
* Added `flex: 1` to both `profileInfoContainer` and `rowContainer` to ensure better layout flexibility and alignment of elements within the row. [[1]](diffhunk://#diff-9202b43b545e7d1c21371e3d137ebdf8a971493862626bf9d9d28e5ede4b8be4L13-R20) [[2]](diffhunk://#diff-9202b43b545e7d1c21371e3d137ebdf8a971493862626bf9d9d28e5ede4b8be4L40-R43)
* Changed `rowContainer` to use `alignItems: 'center'` instead of `justifyContent: 'center'` for improved vertical alignment of row content.

**Text Handling:**

* Updated the display name `TextField` in `SearchResultItem.tsx` to limit to a single line and truncate overflow with an ellipsis (`numberOfLines={1}`, `ellipsizeMode="tail"`), preventing layout issues with long names.
**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

https://github.com/user-attachments/assets/5e2e7bd1-5022-4587-93ea-25738d9e8bbf


**Note (optional) :**
