### PR TITLE
fix: PDT-2795 - showing private brand feed

### DIFF
--- a/src/social/features/user/Profile/Profile.tsx
+++ b/src/social/features/user/Profile/Profile.tsx
@@ -108,13 +108,28 @@ function UserProfile({
             />
           </Tabs.List>
           <Tabs.Content value={UserProfileTab.Feed}>
-            <Feed ref={feedRef} userId={userId} />
+            <Feed
+              ref={feedRef}
+              userId={userId}
+              isBrand={user?.isBrand}
+              isUserLoading={isUserLoading}
+            />
           </Tabs.Content>
           <Tabs.Content value={UserProfileTab.Image}>
-            <ImageFeed ref={feedRef} userId={userId} />
+            <ImageFeed
+              ref={feedRef}
+              userId={userId}
+              isBrand={user?.isBrand}
+              isUserLoading={isUserLoading}
+            />
           </Tabs.Content>
           <Tabs.Content value={UserProfileTab.Video}>
-            <VideoFeed ref={feedRef} userId={userId} />
+            <VideoFeed
+              ref={feedRef}
+              userId={userId}
+              isBrand={user?.isBrand}
+              isUserLoading={isUserLoading}
+            />
           </Tabs.Content>
         </ScrollView>
       </Tabs>

--- a/src/social/features/user/Profile/components/Feed/Feed.tsx
+++ b/src/social/features/user/Profile/components/Feed/Feed.tsx
@@ -11,10 +11,12 @@ import { useFeed } from './hooks/useFeed';
 
 type UserFeedProps = {
   userId: string;
+  isBrand?: boolean;
+  isUserLoading?: boolean;
 };
 
 export const Feed = forwardRef<FeedRef, UserFeedProps>(function Feed(
-  { userId },
+  { userId, isBrand, isUserLoading },
   ref
 ) {
   const { styles } = useStyles();
@@ -31,7 +33,7 @@ export const Feed = forwardRef<FeedRef, UserFeedProps>(function Feed(
     privateInfoConfig,
     blockedConfig,
     blockedInfoConfig,
-  } = useFeed({ userId, ref });
+  } = useFeed({ userId, isBrand, isUserLoading, ref });
 
   if (isBlockedByMe) {
     return (

--- a/src/social/features/user/Profile/components/Feed/hooks/useFeed.ts
+++ b/src/social/features/user/Profile/components/Feed/hooks/useFeed.ts
@@ -8,11 +8,22 @@ import { FeedRef } from '../../../types';
 
 type UseFeedParams = {
   userId: string;
+  isBrand?: boolean;
+  isUserLoading?: boolean;
   ref: React.ForwardedRef<FeedRef>;
 };
 
-export function useFeed({ userId, ref }: UseFeedParams) {
-  const { isBlockedByMe, isPrivate, feedEnabled } = useFeedState({ userId });
+export function useFeed({
+  userId,
+  isBrand,
+  isUserLoading,
+  ref,
+}: UseFeedParams) {
+  const { isBlockedByMe, isPrivate, feedEnabled } = useFeedState({
+    userId,
+    isBrand,
+    isUserLoading,
+  });
 
   const pageId = PageID.user_profile_page;
   const componentId = ComponentID.user_feed;

--- a/src/social/features/user/Profile/components/ImageFeed/ImageFeed.tsx
+++ b/src/social/features/user/Profile/components/ImageFeed/ImageFeed.tsx
@@ -6,10 +6,12 @@ import { useImageFeed } from './hooks/useImageFeed';
 
 type ImageFeedProps = {
   userId: string;
+  isBrand?: boolean;
+  isUserLoading?: boolean;
 };
 
 export const ImageFeed = forwardRef<FeedRef, ImageFeedProps>(function ImageFeed(
-  { userId },
+  { userId, isBrand, isUserLoading },
   ref
 ) {
   const {
@@ -25,7 +27,7 @@ export const ImageFeed = forwardRef<FeedRef, ImageFeedProps>(function ImageFeed(
     privateInfoConfig,
     blockedConfig,
     blockedInfoConfig,
-  } = useImageFeed({ userId, ref });
+  } = useImageFeed({ userId, isBrand, isUserLoading, ref });
 
   if (isBlockedByMe) {
     return (

--- a/src/social/features/user/Profile/components/ImageFeed/hooks/useImageFeed.ts
+++ b/src/social/features/user/Profile/components/ImageFeed/hooks/useImageFeed.ts
@@ -11,13 +11,24 @@ import { FeedRef } from '../../../types';
 
 type UseImageFeedParams = {
   userId: string;
+  isBrand?: boolean;
+  isUserLoading?: boolean;
   ref: React.ForwardedRef<FeedRef>;
 };
 
-export function useImageFeed({ userId, ref }: UseImageFeedParams) {
+export function useImageFeed({
+  userId,
+  isBrand,
+  isUserLoading,
+  ref,
+}: UseImageFeedParams) {
   const navigation =
     useNavigation<NativeStackNavigationProp<RootStackParamList>>();
-  const { isBlockedByMe, isPrivate, feedEnabled } = useFeedState({ userId });
+  const { isBlockedByMe, isPrivate, feedEnabled } = useFeedState({
+    userId,
+    isBrand,
+    isUserLoading,
+  });
 
   const pageId = PageID.user_profile_page;
   const componentId = ComponentID.user_image_feed;

--- a/src/social/features/user/Profile/components/VideoFeed/VideoFeed.tsx
+++ b/src/social/features/user/Profile/components/VideoFeed/VideoFeed.tsx
@@ -6,10 +6,12 @@ import { useVideoFeed } from './hooks/useVideoFeed';
 
 type VideoFeedProps = {
   userId: string;
+  isBrand?: boolean;
+  isUserLoading?: boolean;
 };
 
 export const VideoFeed = forwardRef<FeedRef, VideoFeedProps>(function VideoFeed(
-  { userId },
+  { userId, isBrand, isUserLoading },
   ref
 ) {
   const {
@@ -25,7 +27,7 @@ export const VideoFeed = forwardRef<FeedRef, VideoFeedProps>(function VideoFeed(
     privateInfoConfig,
     blockedConfig,
     blockedInfoConfig,
-  } = useVideoFeed({ userId, ref });
+  } = useVideoFeed({ userId, isBrand, isUserLoading, ref });
 
   if (isBlockedByMe) {
     return (

--- a/src/social/features/user/Profile/components/VideoFeed/hooks/useVideoFeed.ts
+++ b/src/social/features/user/Profile/components/VideoFeed/hooks/useVideoFeed.ts
@@ -11,13 +11,24 @@ import { FeedRef } from '../../../types';
 
 type UseVideoFeedParams = {
   userId: string;
+  isBrand?: boolean;
+  isUserLoading?: boolean;
   ref: React.ForwardedRef<FeedRef>;
 };
 
-export function useVideoFeed({ userId, ref }: UseVideoFeedParams) {
+export function useVideoFeed({
+  userId,
+  isBrand,
+  isUserLoading,
+  ref,
+}: UseVideoFeedParams) {
   const navigation =
     useNavigation<NativeStackNavigationProp<RootStackParamList>>();
-  const { isBlockedByMe, isPrivate, feedEnabled } = useFeedState({ userId });
+  const { isBlockedByMe, isPrivate, feedEnabled } = useFeedState({
+    userId,
+    isBrand,
+    isUserLoading,
+  });
 
   const pageId = PageID.user_profile_page;
   const componentId = ComponentID.user_video_feed;

--- a/src/social/features/user/Profile/hooks/useFeedState.ts
+++ b/src/social/features/user/Profile/hooks/useFeedState.ts
@@ -1,6 +1,6 @@
 import useAuth from '../../../../../core/hooks/useAuth';
 import useSocialSettings from '../../../../../core/hooks/useSocialSettings';
-import { useFollowInfo } from '../../../../hooks/objects';
+import { useFollowInfo, useUser } from '../../../../hooks/objects';
 
 type UseFeedStateParams = {
   userId: string;
@@ -10,13 +10,15 @@ export function useFeedState({ userId }: UseFeedStateParams) {
   const { client } = useAuth();
   const { socialSettings } = useSocialSettings();
   const { followInfo } = useFollowInfo({ userId, enabled: !!userId });
+  const { user } = useUser({ userId });
 
   const isMyProfile = client?.userId === userId;
   const isBlockedByMe = followInfo?.status === 'blocked';
   const isFollowing = followInfo?.status === 'accepted';
+  const isBrandUser = !!user?.isBrand;
   const isPrivate =
     !isMyProfile &&
-    socialSettings?.userPrivacySetting === 'private' &&
+    (isBrandUser || socialSettings?.userPrivacySetting === 'private') &&
     !isFollowing;
 
   return {

--- a/src/social/features/user/Profile/hooks/useFeedState.ts
+++ b/src/social/features/user/Profile/hooks/useFeedState.ts
@@ -1,29 +1,43 @@
 import useAuth from '../../../../../core/hooks/useAuth';
 import useSocialSettings from '../../../../../core/hooks/useSocialSettings';
-import { useFollowInfo, useUser } from '../../../../hooks/objects';
+import { useFollowInfo } from '../../../../hooks/objects';
 
 type UseFeedStateParams = {
   userId: string;
+  /** Pass the already-fetched isBrand value from the parent to avoid a redundant user subscription. */
+  isBrand?: boolean;
+  /**
+   * While true, brand status is still unknown for non-owner viewers.
+   * feedEnabled is held false to prevent a privacy flash before isBrand resolves.
+   */
+  isUserLoading?: boolean;
 };
 
-export function useFeedState({ userId }: UseFeedStateParams) {
+export function useFeedState({
+  userId,
+  isBrand,
+  isUserLoading,
+}: UseFeedStateParams) {
   const { client } = useAuth();
   const { socialSettings } = useSocialSettings();
   const { followInfo } = useFollowInfo({ userId, enabled: !!userId });
-  const { user } = useUser({ userId });
 
   const isMyProfile = client?.userId === userId;
   const isBlockedByMe = followInfo?.status === 'blocked';
   const isFollowing = followInfo?.status === 'accepted';
-  const isBrandUser = !!user?.isBrand;
   const isPrivate =
     !isMyProfile &&
-    (isBrandUser || socialSettings?.userPrivacySetting === 'private') &&
+    (isBrand || socialSettings?.userPrivacySetting === 'private') &&
     !isFollowing;
+
+  // Hold feedEnabled false while the user object is still loading so brand-private
+  // profiles don't flash feed content before isBrand is known.
+  const isBrandResolved = isMyProfile || !isUserLoading;
+  const feedEnabled = isBrandResolved && !isBlockedByMe && !isPrivate;
 
   return {
     isBlockedByMe,
     isPrivate,
-    feedEnabled: !isBlockedByMe && !isPrivate,
+    feedEnabled,
   };
 }


### PR DESCRIPTION
**Jira ticket :**
https://socialplus.atlassian.net/browse/PDT-2795
**Description :**
This pull request updates the `useFeedState` hook to improve how user privacy and brand status are handled. The main change is that the hook now checks if the profile belongs to a brand user and adjusts the privacy logic accordingly.

**User and privacy logic improvements:**

* Added the `useUser` hook to retrieve the user object, allowing checks for the `isBrand` property.
* Updated the `isPrivate` calculation to treat brand users as private unless the viewer is following them, aligning privacy handling for brands with private profiles.
**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

https://github.com/user-attachments/assets/3f663e56-491f-4f81-9744-6a22005aa21e


**Note (optional) :**
