### PR TITLE
fix: PDT-2801 - see more description

### DIFF
--- a/src/social/features/user/Profile/components/Header/Header.tsx
+++ b/src/social/features/user/Profile/components/Header/Header.tsx
@@ -1,8 +1,8 @@
-import { View, TouchableOpacity } from 'react-native';
+import { View, TouchableOpacity, Text, TextLayoutLine } from 'react-native';
 import Avatar from '../../../../../components/Avatar';
 import { BrandBadge } from '../../../../../elements/BrandBadge';
 import { Typography } from '../../../../../../core/components/Typography/Typography';
-import ReadMore from '@fawazahmed/react-native-read-more';
+import { useState } from 'react';
 import { useHeader } from './hooks/useHeader';
 import { UserRelationshipTab } from '../../../../../types';
 import Skeleton from '../../../../../../core/components/Skeleton/Skeleton';
@@ -23,6 +23,26 @@ type HeaderProps = {
 };
 
 export function Header({ user, inline }: HeaderProps) {
+  const [descriptionExpanded, setDescriptionExpanded] = useState(false);
+  const [truncatedDescription, setTruncatedDescription] = useState<
+    string | null
+  >(null);
+
+  const onDescriptionTextLayout = (lines: TextLayoutLine[]) => {
+    if (lines.length <= 4 || truncatedDescription !== null) return;
+    const fourthLine = lines[3];
+    const avgCharWidth = fourthLine.width / (fourthLine.text.length || 1);
+
+    const seeMorePixelWidth = avgCharWidth * '... see more'.length + 4;
+    const charsToRemove = Math.ceil(seeMorePixelWidth / avgCharWidth);
+    const firstThreeText = lines
+      .slice(0, 3)
+      .map((l) => l.text)
+      .join('');
+    const fourthLineText = fourthLine.text.replace(/\n$/, '');
+    const trimmedFourth = fourthLineText.slice(0, -charsToRemove).trimEnd();
+    setTruncatedDescription(firstThreeText + trimmedFourth);
+  };
   const {
     styles,
     showBadge,
@@ -74,15 +94,30 @@ export function Header({ user, inline }: HeaderProps) {
       </View>
       {!!user?.description && (
         <View style={styles.descriptionContainer}>
-          <ReadMore
-            seeLessText=""
-            numberOfLines={4}
-            style={styles.description}
-            seeMoreStyle={styles.seeMore}
-            seeLessStyle={styles.description}
-          >
-            {user.description}
-          </ReadMore>
+          {/* Hidden full text — used only to measure line layout */}
+          {!descriptionExpanded && truncatedDescription === null && (
+            <Text
+              style={[styles.description, styles.hiddenText]}
+              onTextLayout={(e) => onDescriptionTextLayout(e.nativeEvent.lines)}
+            >
+              {user.description}
+            </Text>
+          )}
+          {descriptionExpanded ? (
+            <Text style={styles.description}>{user.description}</Text>
+          ) : (
+            <Text style={styles.description}>
+              {truncatedDescription ?? user.description}
+              {truncatedDescription !== null && (
+                <Text
+                  style={styles.seeMore}
+                  onPress={() => setDescriptionExpanded(true)}
+                >
+                  {'... see more'}
+                </Text>
+              )}
+            </Text>
+          )}
         </View>
       )}
       <View style={styles.followInfoContainer}>

--- a/src/social/features/user/Profile/components/Header/Header.tsx
+++ b/src/social/features/user/Profile/components/Header/Header.tsx
@@ -2,7 +2,7 @@ import { View, TouchableOpacity, Text, TextLayoutLine } from 'react-native';
 import Avatar from '../../../../../components/Avatar';
 import { BrandBadge } from '../../../../../elements/BrandBadge';
 import { Typography } from '../../../../../../core/components/Typography/Typography';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useHeader } from './hooks/useHeader';
 import { UserRelationshipTab } from '../../../../../types';
 import Skeleton from '../../../../../../core/components/Skeleton/Skeleton';
@@ -27,6 +27,11 @@ export function Header({ user, inline }: HeaderProps) {
   const [truncatedDescription, setTruncatedDescription] = useState<
     string | null
   >(null);
+
+  useEffect(() => {
+    setDescriptionExpanded(false);
+    setTruncatedDescription(null);
+  }, [user?.userId, user?.description]);
 
   const onDescriptionTextLayout = (lines: TextLayoutLine[]) => {
     if (lines.length <= 4 || truncatedDescription !== null) return;

--- a/src/social/features/user/Profile/components/Header/styles.ts
+++ b/src/social/features/user/Profile/components/Header/styles.ts
@@ -49,6 +49,10 @@ export const useStyles = (
       fontWeight: '400',
       lineHeight: 20,
     },
+    hiddenText: {
+      position: 'absolute',
+      opacity: 0,
+    },
     seeMore: {
       color: theme.colors.primary,
       fontSize: 15,


### PR DESCRIPTION
**Jira ticket :**
https://socialplus.atlassian.net/browse/PDT-2801
**Description :**
This pull request updates the user profile header to replace the third-party `ReadMore` component with a custom "see more" implementation for user descriptions. The new approach improves control over truncation and display, and introduces a hidden measurement technique to ensure clean truncation at four lines with a custom "see more" prompt.

Key changes:

**Custom "See More" Description Implementation:**

* Replaces the `ReadMore` component with a custom logic that measures the rendered text, truncates the user description to four lines, and appends a "... see more" link to expand the full text. This is achieved by using the `onTextLayout` callback and React state to manage truncation and expansion. [[1]](diffhunk://#diff-91ad312135ca857caf2eb4f2cd44ced4305071a1cf28dcc5bb5fe09c1398e71cL1-R5) [[2]](diffhunk://#diff-91ad312135ca857caf2eb4f2cd44ced4305071a1cf28dcc5bb5fe09c1398e71cR26-R45) [[3]](diffhunk://#diff-91ad312135ca857caf2eb4f2cd44ced4305071a1cf28dcc5bb5fe09c1398e71cL77-R120)

**Styling Adjustments:**

* Adds a new `hiddenText` style to render a hidden `Text` component for layout measurement, ensuring the visible text is truncated accurately without affecting the layout.
**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

https://github.com/user-attachments/assets/50dfbd16-b5b9-47a6-8508-4744000fbe20


**Note (optional) :**
