### PR TITLE
fix: PDT-2797 - reaction list navigation

### DIFF
--- a/src/social/components/CommunityStories/index.tsx
+++ b/src/social/components/CommunityStories/index.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useState } from 'react';
+import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { Image, TouchableOpacity, View } from 'react-native';
 import { useStyles } from './styles';
 import { useStory } from '../../hooks/useStory';
@@ -35,6 +35,7 @@ const CommunityStories = ({ communityId, community }: ICommunityStories) => {
   const { getImage } = useFile();
   const [avatarUrl, setAvatarUrl] = useState(undefined);
   const [viewStory, setViewStory] = useState(false);
+  const shouldRestoreStory = useRef(false);
   const storyRingColor: string[] =
     hasStoryPermission && storyTarget?.failedStoriesCount > 0
       ? ['#DE1029', '#DE1029']
@@ -61,6 +62,11 @@ const CommunityStories = ({ communityId, community }: ICommunityStories) => {
 
   useFocusEffect(
     useCallback(() => {
+      if (shouldRestoreStory.current) {
+        shouldRestoreStory.current = false;
+        setViewStory(true);
+        return;
+      }
       getStoryTarget({
         targetId: communityId,
         targetType: 'community',
@@ -173,6 +179,15 @@ const CommunityStories = ({ communityId, community }: ICommunityStories) => {
     return null;
   };
 
+  const handleNavigateToUser = useCallback(
+    (userId: string) => {
+      shouldRestoreStory.current = true;
+      setViewStory(false);
+      navigation.navigate('UserProfile', { userId });
+    },
+    [navigation]
+  );
+
   const onFinish = useCallback(() => {
     setViewStory(false);
     getStoryTarget({
@@ -204,6 +219,7 @@ const CommunityStories = ({ communityId, community }: ICommunityStories) => {
           onFinish={onFinish}
           onPressAvatar={onPressAvatar}
           onPressCommunityName={onPressCommunityName}
+          onNavigateToUser={handleNavigateToUser}
         />
       </Modal>
     </View>

--- a/src/social/components/MyStories/StoryTargetView.tsx
+++ b/src/social/components/MyStories/StoryTargetView.tsx
@@ -82,6 +82,18 @@ const StoryTargetView: FC<IStorytargetView> = ({
     ]
   );
 
+  const handleNavigateToUser = useCallback(
+    (userId: string) => {
+      setViewStory(false);
+      navigation.navigate('UserProfile', { userId });
+      const unsubscribe = navigation.addListener('focus', () => {
+        unsubscribe();
+        setViewStory(true);
+      });
+    },
+    [navigation, setViewStory]
+  );
+
   if (Platform.OS === 'ios') {
     return (
       <CubeNavigationHorizontal
@@ -101,6 +113,7 @@ const StoryTargetView: FC<IStorytargetView> = ({
               onFinish={onFinish}
               onPressAvatar={onPressAvatar}
               onPressCommunityName={onPressCommunityName}
+              onNavigateToUser={handleNavigateToUser}
               index={i}
               currentPage={currentCommunityIndex}
             />
@@ -127,6 +140,7 @@ const StoryTargetView: FC<IStorytargetView> = ({
               onFinish={onFinish}
               onPressAvatar={onPressAvatar}
               onPressCommunityName={onPressCommunityName}
+              onNavigateToUser={handleNavigateToUser}
               index={i}
               currentPage={currentCommunityIndex}
             />

--- a/src/social/components/Social/CommentList/CommentList.tsx
+++ b/src/social/components/Social/CommentList/CommentList.tsx
@@ -36,7 +36,7 @@ interface ICommentListProp {
   postId: string;
   postType: Amity.CommentReferenceType;
   disabledInteraction?: boolean;
-  onNavigate?: () => void;
+  onNavigate?: (userId: string) => void;
   withAvatar?: boolean;
   disabledComment?: boolean;
 }

--- a/src/social/components/Social/CommentListItem/CommentListItem.tsx
+++ b/src/social/components/Social/CommentListItem/CommentListItem.tsx
@@ -37,8 +37,8 @@ import {
 import EditCommentModal from '../../legacy/EditCommentModal';
 import { useTheme } from 'react-native-paper';
 import type { MyMD3Theme } from '../../../../core/providers/AmityUIKitProvider';
-import { useNavigation } from '@react-navigation/native';
 import ReplyCommentList from '../../legacy/Social/ReplyCommentList';
+import AmityReactionListComponent from '../../../features/reaction/components/List';
 import { CommentRepository } from '@amityco/ts-sdk-react-native';
 import { useTimeDifference } from '../../../hooks/useTimeDifference';
 import { LinkPreview } from '../../PreviewLink';
@@ -69,7 +69,6 @@ export interface ICommentList {
   postType: Amity.CommentReferenceType;
   disabledInteraction?: boolean;
   disabledComment?: boolean;
-  onNavigate?: () => void;
 }
 
 const CommentListItem = ({
@@ -78,7 +77,6 @@ const CommentListItem = ({
   onClickReply,
   postType,
   disabledInteraction,
-  onNavigate,
   disabledComment,
 }: ICommentList) => {
   const theme = useTheme() as MyMD3Theme;
@@ -122,7 +120,8 @@ const CommentListItem = ({
   const [editCommentModal, setEditCommentModal] = useState<boolean>(false);
   const [isEditComment, setIsEditComment] = useState<boolean>(false);
   const slideAnimation = useRef(new Animated.Value(0)).current;
-  const navigation = useNavigation<any>();
+  const [isReactionListVisible, setIsReactionListVisible] =
+    useState<boolean>(false);
   const { showToast } = useToast();
 
   useEffect(() => {
@@ -286,11 +285,7 @@ const CommentListItem = ({
   };
 
   const onPressCommentReaction = () => {
-    onNavigate && onNavigate();
-    navigation.navigate('ReactionList', {
-      referenceId: commentId,
-      referenceType: 'comment',
-    });
+    setIsReactionListVisible(true);
   };
 
   return (
@@ -498,6 +493,12 @@ const CommentListItem = ({
         commentDetail={commentDetail}
         onFinishEdit={onEditComment}
         onClose={onCloseEditCommentModal}
+      />
+      <AmityReactionListComponent
+        isModalVisible={isReactionListVisible}
+        onCloseModal={() => setIsReactionListVisible(false)}
+        referenceId={commentId}
+        referenceType="comment"
       />
     </View>
   );

--- a/src/social/components/Social/CommentListItem/CommentListItem.tsx
+++ b/src/social/components/Social/CommentListItem/CommentListItem.tsx
@@ -312,11 +312,13 @@ const CommentListItem = ({
         <View style={styles.rightSection}>
           <View style={styles.headerRow}>
             <TouchableOpacity
+              disabled={!user?.userId}
               onPress={() => {
+                if (!user?.userId) return;
                 if (onNavigate) {
-                  onNavigate(user?.userId);
+                  onNavigate(user.userId);
                 } else {
-                  navigation.navigate('UserProfile', { userId: user?.userId });
+                  navigation.navigate('UserProfile', { userId: user.userId });
                 }
               }}
             >

--- a/src/social/components/Social/CommentListItem/CommentListItem.tsx
+++ b/src/social/components/Social/CommentListItem/CommentListItem.tsx
@@ -37,6 +37,9 @@ import {
 import EditCommentModal from '../../legacy/EditCommentModal';
 import { useTheme } from 'react-native-paper';
 import type { MyMD3Theme } from '../../../../core/providers/AmityUIKitProvider';
+import { useNavigation } from '@react-navigation/native';
+import { StackNavigationProp } from '@react-navigation/stack';
+import { RootStackParamList } from '../../../../core/routes/RouteParamList';
 import ReplyCommentList from '../../legacy/Social/ReplyCommentList';
 import AmityReactionListComponent from '../../../features/reaction/components/List';
 import { CommentRepository } from '@amityco/ts-sdk-react-native';
@@ -69,6 +72,7 @@ export interface ICommentList {
   postType: Amity.CommentReferenceType;
   disabledInteraction?: boolean;
   disabledComment?: boolean;
+  onNavigate?: (userId: string) => void;
 }
 
 const CommentListItem = ({
@@ -78,6 +82,7 @@ const CommentListItem = ({
   postType,
   disabledInteraction,
   disabledComment,
+  onNavigate,
 }: ICommentList) => {
   const theme = useTheme() as MyMD3Theme;
   const styles = useStyles();
@@ -122,6 +127,7 @@ const CommentListItem = ({
   const slideAnimation = useRef(new Animated.Value(0)).current;
   const [isReactionListVisible, setIsReactionListVisible] =
     useState<boolean>(false);
+  const navigation = useNavigation<StackNavigationProp<RootStackParamList>>();
   const { showToast } = useToast();
 
   useEffect(() => {
@@ -305,7 +311,17 @@ const CommentListItem = ({
         )}
         <View style={styles.rightSection}>
           <View style={styles.headerRow}>
-            <Text style={styles.headerText}>{user?.displayName}</Text>
+            <TouchableOpacity
+              onPress={() => {
+                if (onNavigate) {
+                  onNavigate(user?.userId);
+                } else {
+                  navigation.navigate('UserProfile', { userId: user?.userId });
+                }
+              }}
+            >
+              <Text style={styles.headerText}>{user?.displayName}</Text>
+            </TouchableOpacity>
           </View>
 
           <View style={styles.commentBubble}>
@@ -381,6 +397,7 @@ const CommentListItem = ({
                 previewReplyCommentList[previewReplyCommentList.length - 1]
               }
               onDelete={onDelete}
+              onNavigate={onNavigate}
             />
           )}
           {isOpenReply && (
@@ -391,6 +408,7 @@ const CommentListItem = ({
                   commentId={item.commentId}
                   commentDetail={item}
                   onDelete={onDelete}
+                  onNavigate={onNavigate}
                 />
               )}
               keyExtractor={(item, index) => item.commentId + index}
@@ -499,6 +517,14 @@ const CommentListItem = ({
         onCloseModal={() => setIsReactionListVisible(false)}
         referenceId={commentId}
         referenceType="comment"
+        onPressUser={(userId) => {
+          setIsReactionListVisible(false);
+          if (onNavigate) {
+            onNavigate(userId);
+          } else {
+            navigation.navigate('UserProfile', { userId });
+          }
+        }}
       />
     </View>
   );

--- a/src/social/components/legacy/Social/ReplyCommentList/index.tsx
+++ b/src/social/components/legacy/Social/ReplyCommentList/index.tsx
@@ -232,11 +232,13 @@ export default function ReplyCommentList({
         <View style={styles.rightSection}>
           <View style={styles.headerRow}>
             <TouchableOpacity
+              disabled={!user?.userId}
               onPress={() => {
+                if (!user?.userId) return;
                 if (onNavigate) {
-                  onNavigate(user?.userId);
+                  onNavigate(user.userId);
                 } else {
-                  navigation.navigate('UserProfile', { userId: user?.userId });
+                  navigation.navigate('UserProfile', { userId: user.userId });
                 }
               }}
             >

--- a/src/social/components/legacy/Social/ReplyCommentList/index.tsx
+++ b/src/social/components/legacy/Social/ReplyCommentList/index.tsx
@@ -45,6 +45,7 @@ import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../../../../../core/routes/RouteParamList';
 import { useTimeDifference } from '../../../../hooks';
 import { useToast } from '../../../../../core/stores/slices/toastSlice';
+import AmityReactionListComponent from '../../../../features/reaction/components/List';
 
 export interface IComment {
   commentId: string;
@@ -66,12 +67,14 @@ export interface IReplyCommentList {
   commentId: string;
   commentDetail: IComment;
   onDelete?: (commentId: string) => void;
+  onNavigate?: (userId: string) => void;
 }
 
 export default function ReplyCommentList({
   commentDetail,
   onDelete,
   commentId,
+  onNavigate,
 }: IReplyCommentList) {
   const {
     // commentId,
@@ -105,6 +108,8 @@ export default function ReplyCommentList({
   const [commentMentionPosition, setCommentMentionPosition] = useState<
     IMentionPosition[]
   >([]);
+  const [isReactionListVisible, setIsReactionListVisible] =
+    useState<boolean>(false);
   const navigation =
     useNavigation<NativeStackNavigationProp<RootStackParamList>>();
 
@@ -206,10 +211,7 @@ export default function ReplyCommentList({
   };
 
   const onPressReplyReaction = () => {
-    navigation.navigate('ReactionList', {
-      referenceId: commentId,
-      referenceType: 'comment',
-    });
+    setIsReactionListVisible(true);
   };
 
   return (
@@ -229,7 +231,17 @@ export default function ReplyCommentList({
         )}
         <View style={styles.rightSection}>
           <View style={styles.headerRow}>
-            <Text style={styles.headerText}>{user?.displayName}</Text>
+            <TouchableOpacity
+              onPress={() => {
+                if (onNavigate) {
+                  onNavigate(user?.userId);
+                } else {
+                  navigation.navigate('UserProfile', { userId: user?.userId });
+                }
+              }}
+            >
+              <Text style={styles.headerText}>{user?.displayName}</Text>
+            </TouchableOpacity>
           </View>
 
           <View style={styles.commentBubble}>
@@ -367,6 +379,20 @@ export default function ReplyCommentList({
         commentDetail={commentDetail}
         onFinishEdit={onEditComment}
         onClose={onCloseEditCommentModal}
+      />
+      <AmityReactionListComponent
+        isModalVisible={isReactionListVisible}
+        onCloseModal={() => setIsReactionListVisible(false)}
+        referenceId={commentId}
+        referenceType="comment"
+        onPressUser={(userId) => {
+          setIsReactionListVisible(false);
+          if (onNavigate) {
+            onNavigate(userId);
+          } else {
+            navigation.navigate('UserProfile', { userId });
+          }
+        }}
       />
     </View>
   );

--- a/src/social/features/reaction/components/List/List.tsx
+++ b/src/social/features/reaction/components/List/List.tsx
@@ -31,6 +31,7 @@ type AmityReactionListComponentType = {
   referenceType: Amity.ReactableType;
   isModalVisible: boolean;
   onCloseModal: () => void;
+  onPressUser?: (userId: string) => void;
 };
 
 type ReactionListType = Amity.User & { reactionName: string };
@@ -40,6 +41,7 @@ const AmityReactionListComponent: FC<AmityReactionListComponentType> = ({
   referenceType,
   isModalVisible,
   onCloseModal,
+  onPressUser,
 }) => {
   const styles = useStyles();
   const theme = useTheme() as MyMD3Theme;
@@ -133,9 +135,13 @@ const AmityReactionListComponent: FC<AmityReactionListComponentType> = ({
   const onPressReactor = useCallback(
     (userId: string) => {
       onCloseModal();
-      navigation.navigate('UserProfile', { userId });
+      if (onPressUser) {
+        onPressUser(userId);
+      } else {
+        navigation.navigate('UserProfile', { userId });
+      }
     },
-    [navigation, onCloseModal]
+    [navigation, onCloseModal, onPressUser]
   );
 
   const renderReactors = useCallback(

--- a/src/social/features/story/View/View.tsx
+++ b/src/social/features/story/View/View.tsx
@@ -17,6 +17,7 @@ interface IAmityViewStoryPage {
   onFinish?: (state?: NextOrPrevious, targetId?: string) => void;
   onPressCommunityName?: () => void;
   onPressAvatar?: () => void;
+  onNavigateToUser?: (userId: string) => void;
 }
 
 interface IStoryData extends Amity.Story {
@@ -31,6 +32,7 @@ const AmityViewStoryPage: FC<IAmityViewStoryPage> = ({
   onPressAvatar,
   currentPage,
   index,
+  onNavigateToUser,
 }) => {
   const { client } = useAuth();
   const userId = (client as Amity.Client).userId;
@@ -140,6 +142,7 @@ const AmityViewStoryPage: FC<IAmityViewStoryPage> = ({
         hasStoryPermission={hasStoryPermission}
         onPressAvatar={onPressAvatar}
         onPressCommunityName={onPressCommunityName}
+        onNavigateToUser={onNavigateToUser}
       />
     );
   }

--- a/src/social/features/story/View/components/AmityViewStoryItem.tsx
+++ b/src/social/features/story/View/components/AmityViewStoryItem.tsx
@@ -58,6 +58,7 @@ interface IAmityViewStoryItem {
   hasStoryPermission: boolean;
   onPressAvatar?: () => void;
   onPressCommunityName?: () => void;
+  onNavigateToUser?: (userId: string) => void;
 }
 
 interface IStoryData extends Amity.Story {
@@ -76,6 +77,7 @@ const AmityViewStoryItem: FC<IAmityViewStoryItem> = ({
   hasStoryPermission,
   onPressAvatar,
   onPressCommunityName,
+  onNavigateToUser,
 }) => {
   const styles = useStyles();
   const theme = useTheme<MyMD3Theme>();
@@ -239,6 +241,14 @@ const AmityViewStoryItem: FC<IAmityViewStoryItem> = ({
     startAnimation();
     setPressed(false);
   }, [startAnimation]);
+
+  const onNavigateFromComment = useCallback(
+    (userId: string) => {
+      onClosedCommentSheet();
+      onNavigateToUser && onNavigateToUser(userId);
+    },
+    [onClosedCommentSheet, onNavigateToUser]
+  );
 
   const deleteStory = useCallback(async () => {
     setLoading(true);
@@ -609,7 +619,7 @@ const AmityViewStoryItem: FC<IAmityViewStoryItem> = ({
               postType="story"
               disabledComment={!communityData?.allowCommentInStory}
               disabledInteraction={!communityData?.isJoined}
-              onNavigate={onClose}
+              onNavigate={onNavigateFromComment}
             />
           </KeyboardAvoidingView>
         </Modal>


### PR DESCRIPTION
**Jira ticket :**
https://socialplus.atlassian.net/browse/PDT-2797
**Description :**
This pull request introduces several improvements to user navigation and the handling of reaction lists within comments and stories. The main focus is on providing a consistent way to navigate to user profiles from various components (such as comments, replies, and stories), and on updating the reaction list modal to support custom navigation behavior. Additionally, the code has been refactored to pass navigation handlers through props, improving flexibility and maintainability.

**User Navigation Enhancements:**

* Added an `onNavigate` (or `onNavigateToUser`) callback prop to comment, reply, and story components, allowing parent components to control navigation to user profiles. This enables more flexible navigation flows and better state management when moving between screens. [[1]](diffhunk://#diff-5fa98b465e0a594af957bb944bb6e124370c80fb6a374f4bf366100ececafac4L39-R39) [[2]](diffhunk://#diff-d04685d34db72ea3344d9cc646e885826190cf92c60a6fbfa23ba01ee619b73fL72-R75) [[3]](diffhunk://#diff-a67ee7f505d3a022c90e8c51a922dbfd82f21126982d452514a26f7d5e9989b1R70-R77) [[4]](diffhunk://#diff-75dcec7c047c82a61f16b14a4f8748152b22644d030495188138b669ee1d1498R20) [[5]](diffhunk://#diff-c39ab2e4e1fe63c34cc3bc193f7efc55a5a948771a52665bd4a02aeb24afcda1R61)
* Updated all places where user display names are rendered in comments and replies to wrap them in a `TouchableOpacity` that triggers navigation to the user's profile, using the new navigation handler if provided. [[1]](diffhunk://#diff-d04685d34db72ea3344d9cc646e885826190cf92c60a6fbfa23ba01ee619b73fR314-R324) [[2]](diffhunk://#diff-a67ee7f505d3a022c90e8c51a922dbfd82f21126982d452514a26f7d5e9989b1R234-R244)

**Reaction List Modal Improvements:**

* Refactored the reaction list modal (`AmityReactionListComponent`) to accept an `onPressUser` prop, which is called when a user in the reaction list is selected. If not provided, the modal defaults to navigating to the user's profile. [[1]](diffhunk://#diff-0e742503206c1112d3cc39042da6d4c813005142698478734de51f95d6705a0eR34) [[2]](diffhunk://#diff-0e742503206c1112d3cc39042da6d4c813005142698478734de51f95d6705a0eR138-R144)
* Updated comment and reply components to open the reaction list modal internally (rather than navigating to a separate screen), and to use the new `onPressUser` handler for user navigation from the modal. [[1]](diffhunk://#diff-d04685d34db72ea3344d9cc646e885826190cf92c60a6fbfa23ba01ee619b73fL289-R294) [[2]](diffhunk://#diff-d04685d34db72ea3344d9cc646e885826190cf92c60a6fbfa23ba01ee619b73fR515-R528) [[3]](diffhunk://#diff-a67ee7f505d3a022c90e8c51a922dbfd82f21126982d452514a26f7d5e9989b1L209-R214) [[4]](diffhunk://#diff-a67ee7f505d3a022c90e8c51a922dbfd82f21126982d452514a26f7d5e9989b1R383-R396)

**Story View Navigation Handling:**

* Introduced an `onNavigateToUser` prop throughout the story view components, allowing navigation to a user's profile from within stories (including when viewing comments on a story). [[1]](diffhunk://#diff-75dcec7c047c82a61f16b14a4f8748152b22644d030495188138b669ee1d1498R20) [[2]](diffhunk://#diff-75dcec7c047c82a61f16b14a4f8748152b22644d030495188138b669ee1d1498R35) [[3]](diffhunk://#diff-75dcec7c047c82a61f16b14a4f8748152b22644d030495188138b669ee1d1498R145) [[4]](diffhunk://#diff-c39ab2e4e1fe63c34cc3bc193f7efc55a5a948771a52665bd4a02aeb24afcda1R61) [[5]](diffhunk://#diff-c39ab2e4e1fe63c34cc3bc193f7efc55a5a948771a52665bd4a02aeb24afcda1R80) [[6]](diffhunk://#diff-c39ab2e4e1fe63c34cc3bc193f7efc55a5a948771a52665bd4a02aeb24afcda1R245-R252)
* Implemented logic to correctly restore the story view state when navigating back from a user profile, ensuring a smooth user experience. [[1]](diffhunk://#diff-e06f8fd0dfcdf84df95d0c1594e2316eaf2cdb73ad4630bf793185b1d9e99cf4R38) [[2]](diffhunk://#diff-e06f8fd0dfcdf84df95d0c1594e2316eaf2cdb73ad4630bf793185b1d9e99cf4R65-R69) [[3]](diffhunk://#diff-e06f8fd0dfcdf84df95d0c1594e2316eaf2cdb73ad4630bf793185b1d9e99cf4R182-R190) [[4]](diffhunk://#diff-e0427da015f31735a47360eb2f5b8003502af2762f31ea5444345bc3fef70da5R85-R96) [[5]](diffhunk://#diff-e0427da015f31735a47360eb2f5b8003502af2762f31ea5444345bc3fef70da5R116) [[6]](diffhunk://#diff-e0427da015f31735a47360eb2f5b8003502af2762f31ea5444345bc3fef70da5R143)

These changes collectively improve the modularity and user experience of navigation within the social features of the app.
**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

https://github.com/user-attachments/assets/5b87f740-3bf9-4765-ae4d-bb64bbac6eb4


**Note (optional) :**
