### PR TITLE
fix: PDT-2812 - image order viewer

### DIFF
--- a/src/social/elements/ImageViewer/ImageViewer.tsx
+++ b/src/social/elements/ImageViewer/ImageViewer.tsx
@@ -121,9 +121,9 @@ const ImageViewer: FC<ImageViewerProps> = ({
           pagingEnabled
           showsHorizontalScrollIndicator={false}
           onMomentumScrollEnd={handleScroll}
-          // contentContainerStyle={styles.scrollView}
           scrollEventThrottle={16}
           decelerationRate="fast"
+          contentOffset={{ x: width * currentImageIndex, y: 0 }}
         >
           {images.map((imageUrl, index) => (
             <View key={`image-${index}`} style={styles.imageContainer}>

--- a/src/social/elements/ImageViewer/ImageViewer.tsx
+++ b/src/social/elements/ImageViewer/ImageViewer.tsx
@@ -31,6 +31,7 @@ const ImageViewer: FC<ImageViewerProps> = ({
 }) => {
   const [active, setActive] = useState(currentImageIndex);
   const scrollViewRef = useRef<ScrollView>(null);
+  const hasScrolledToInitial = useRef(false);
   const { width, height } = Dimensions.get('window');
 
   useEffect(() => {
@@ -95,6 +96,18 @@ const ImageViewer: FC<ImageViewerProps> = ({
     },
   });
 
+  const handleInitialScroll = () => {
+    if (!hasScrolledToInitial.current) {
+      hasScrolledToInitial.current = true;
+      if (currentImageIndex > 0) {
+        scrollViewRef.current?.scrollTo({
+          x: width * currentImageIndex,
+          animated: false,
+        });
+      }
+    }
+  };
+
   const handleScroll = (event) => {
     const contentOffsetX = event.nativeEvent.contentOffset.x;
     const newIndex = Math.round(contentOffsetX / width);
@@ -121,6 +134,7 @@ const ImageViewer: FC<ImageViewerProps> = ({
           pagingEnabled
           showsHorizontalScrollIndicator={false}
           onMomentumScrollEnd={handleScroll}
+          onContentSizeChange={handleInitialScroll}
           scrollEventThrottle={16}
           decelerationRate="fast"
           contentOffset={{ x: width * currentImageIndex, y: 0 }}


### PR DESCRIPTION
**Jira ticket :**
https://socialplus.atlassian.net/browse/PDT-2812
**Description :**
This pull request makes a small change to the `ImageViewer` component to improve the user experience when displaying images. The main update is the addition of the `contentOffset` prop to the `ScrollView`, ensuring that the viewer opens scrolled to the currently selected image.

- **Image display improvement:**
  * [`src/social/elements/ImageViewer/ImageViewer.tsx`](diffhunk://#diff-b7e8d3559d50b28d28c470599861b50056607fcfba28d9f272dbd647d7486c4aL124-R126): Added the `contentOffset` prop to the `ScrollView` to automatically scroll to the image at `currentImageIndex` when the viewer opens.
**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

https://github.com/user-attachments/assets/68fdf1cd-2fbd-4982-bef3-3925a8cdd185


**Note (optional) :**
