### PR TITLE
fix: PDT-2813 - video tab error

### DIFF
--- a/src/social/elements/VideoGallery/VideoGallery.tsx
+++ b/src/social/elements/VideoGallery/VideoGallery.tsx
@@ -81,8 +81,9 @@ const VideoGallery: FC<VideoGalleryProps> = ({
           item: Amity.Post<'video'>;
           index: number;
         }) => {
-          const uri = item.getVideoThumbnailInfo()?.fileUrl
-            ? item.getVideoThumbnailInfo()!.fileUrl + '?size=medium'
+          const videoThumbnailInfo = item.getVideoThumbnailInfo();
+          const uri = videoThumbnailInfo?.fileUrl
+            ? videoThumbnailInfo.fileUrl + '?size=medium'
             : undefined;
           const videoInfo = item.getVideoInfo();
           const duration = formatDuration(

--- a/src/social/elements/VideoGallery/VideoGallery.tsx
+++ b/src/social/elements/VideoGallery/VideoGallery.tsx
@@ -81,8 +81,10 @@ const VideoGallery: FC<VideoGalleryProps> = ({
           item: Amity.Post<'video'>;
           index: number;
         }) => {
-          const uri = item.getVideoThumbnailInfo().fileUrl + '?size=medium';
-          const videoInfo = item.getVideoInfo() as Amity.File<'video'>;
+          const uri = item.getVideoThumbnailInfo()?.fileUrl
+            ? item.getVideoThumbnailInfo()!.fileUrl + '?size=medium'
+            : undefined;
+          const videoInfo = item.getVideoInfo();
           const duration = formatDuration(
             (videoInfo?.attributes?.metadata?.video as Amity.VideoMetadata)
               ?.duration as number
@@ -129,7 +131,7 @@ const VideoGallery: FC<VideoGalleryProps> = ({
             playWhenInactive={false}
             playInBackground={false}
             source={{
-              uri: posts[currentImageIndex].getVideoInfo().fileUrl,
+              uri: posts[currentImageIndex].getVideoInfo()?.fileUrl,
             }}
             fullscreenOrientation="all"
           />


### PR DESCRIPTION
**Jira ticket :**
https://socialplus.atlassian.net/browse/PDT-2813
**Description :**
This pull request makes the `VideoGallery` component more robust by adding null checks when accessing video and thumbnail information. This helps prevent runtime errors if certain video data is missing.

**Improvements to error handling and robustness:**

* Added null checks when accessing `fileUrl` from `getVideoThumbnailInfo()` and `getVideoInfo()` to avoid errors when these values are undefined. (`src/social/elements/VideoGallery/VideoGallery.tsx`) [[1]](diffhunk://#diff-00f1d03612c66b5302c52f6c8097f965f87588ce141e510b9be8ec5e25428a79L84-R87) [[2]](diffhunk://#diff-00f1d03612c66b5302c52f6c8097f965f87588ce141e510b9be8ec5e25428a79L132-R134)
**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

**Note (optional) :**

https://github.com/user-attachments/assets/03381d57-2cd0-45ac-85e5-04b4c8a659ce

