### PR TITLE
fix: PDT-2811 - story aspect radio

### DIFF
--- a/src/social/features/story/Draft/Draft.tsx
+++ b/src/social/features/story/Draft/Draft.tsx
@@ -42,14 +42,12 @@ const AmityDraftStoryPage: FC<IAmityDraftStoryPage> = ({
   const type = getMediaTypeFromUrl(mediaType.uri);
   const styles = useStyles();
   const { getImage } = useFile();
-  const [isFullScreen, setIsFullScreen] = useState(false);
+  const [imageDisplayMode, setImageDisplayMode] =
+    useState<Amity.ImageDisplayMode>('fit');
   const [isVisibleModal, setIsVisibleModal] = useState(false);
   const [communityAvatarUrl, setCommunityAvatarUrl] = useState<string>(null);
   const [hyperlink, setHyperlink] = useState<Amity.StoryItem[]>(undefined);
   const [loading, setLoading] = useState(false);
-  const imageDisplayMode: Amity.ImageDisplayMode = isFullScreen
-    ? 'fill'
-    : 'fit';
   const theme = useTheme() as MyMD3Theme;
   const aspectRatioIcon = useConfigImageUri({
     configPath: {
@@ -106,7 +104,7 @@ const AmityDraftStoryPage: FC<IAmityDraftStoryPage> = ({
   }, [onDiscardStory]);
 
   const onPressAspectRatio = useCallback(() => {
-    setIsFullScreen((prev) => !prev);
+    setImageDisplayMode((prev) => (prev === 'fit' ? 'fill' : 'fit'));
   }, []);
 
   const onPressHyperLink = useCallback(() => {
@@ -184,14 +182,16 @@ const AmityDraftStoryPage: FC<IAmityDraftStoryPage> = ({
         {type === StoryType.image ? (
           <Image
             source={{ uri: mediaType.uri }}
-            style={[styles.image, isFullScreen && styles.aspect_ratio]}
+            style={styles.image}
+            resizeMode={imageDisplayMode === 'fill' ? 'cover' : 'contain'}
           />
         ) : (
           <Video
             paused={loading}
             repeat
             source={{ uri: mediaType.uri }}
-            style={[styles.image, isFullScreen && styles.aspect_ratio]}
+            style={styles.image}
+            resizeMode={imageDisplayMode === 'fill' ? 'cover' : 'contain'}
           />
         )}
       </View>

--- a/src/social/features/story/Draft/styles.ts
+++ b/src/social/features/story/Draft/styles.ts
@@ -39,13 +39,9 @@ export const useStyles = () => {
       justifyContent: 'center',
       overflow: 'hidden',
     },
-    aspect_ratio: {
-      width: '100%',
-      height: '100%',
-    },
     image: {
       width: '100%',
-      height: '60%',
+      height: '100%',
     },
     shareStoryBtn: {
       marginTop: 16,

--- a/src/social/features/story/View/components/AmityViewStoryItem.tsx
+++ b/src/social/features/story/View/components/AmityViewStoryItem.tsx
@@ -364,7 +364,11 @@ const AmityViewStoryItem: FC<IAmityViewStoryItem> = ({
                   opacity: 0.6,
                 },
               ]}
-              resizeMode="contain"
+              resizeMode={
+                currentStory?.data?.imageDisplayMode === 'fill'
+                  ? 'cover'
+                  : 'contain'
+              }
             />
           ) : null}
           {load && (


### PR DESCRIPTION
**Jira ticket :**
https://socialplus.atlassian.net/browse/PDT-2811
**Description :**
This pull request refactors how image and video display modes are managed in the story draft and view components. The previous boolean-based fullscreen logic is replaced with a more explicit `imageDisplayMode` state, improving code clarity and flexibility. It also adjusts the styling to ensure images and videos use the correct aspect ratio based on the selected display mode.

Display mode logic improvements:

* Replaced the `isFullScreen` boolean state with an explicit `imageDisplayMode` state (`'fit'` or `'fill'`) in `Draft.tsx`, and updated the toggle logic to switch between these modes. [[1]](diffhunk://#diff-29876f1aa91af78515dc42b8f41d3455903e29817d193207f91f6b706bd267deL45-L52) [[2]](diffhunk://#diff-29876f1aa91af78515dc42b8f41d3455903e29817d193207f91f6b706bd267deL109-R107)
* Updated the rendering of `Image` and `Video` components in `Draft.tsx` to use the `resizeMode` prop (`'cover'` for `'fill'`, `'contain'` for `'fit'`), ensuring the media is displayed according to the selected mode.
* In `AmityViewStoryItem.tsx`, changed the `resizeMode` of images to depend on the `imageDisplayMode` property of the current story, supporting both `'fill'` and `'fit'` modes.

Styling adjustments:

* Removed the redundant `aspect_ratio` style and set the image height to 100% in the `useStyles` hook, ensuring consistent sizing regardless of display mode.
**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

https://github.com/user-attachments/assets/92dce541-b275-4340-a24e-bfd5801fe415


**Note (optional) :**
