### PR TITLE
fix: PDT-2807 - image resolution

### DIFF
--- a/src/social/components/Avatar/Avatar.tsx
+++ b/src/social/components/Avatar/Avatar.tsx
@@ -17,6 +17,7 @@ import { isModerator } from '../../utils/permissions';
 import { RootStackParamList } from '../../../core/routes/RouteParamList';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useNavigation } from '@react-navigation/native';
+import { getFileUrlWithSize } from '../../utils';
 
 type AvatarProps = {
   uri?: string;
@@ -40,7 +41,8 @@ function Avatar({ uri, imageProps, iconProps, userAvatarProps }: AvatarProps) {
 
   const handlePress = () => {
     if (userAvatarProps?.viewable && uri) {
-      navigation.navigate('ImageViewer', { images: [{ uri }] });
+      const largeUri = getFileUrlWithSize(uri, 'large');
+      navigation.navigate('ImageViewer', { images: [{ uri: largeUri }] });
     } else if (userAvatarProps?.shouldRedirectToUserProfile) {
       navigation.navigate('UserProfile', { userId: userAvatarProps?.userId });
     }


### PR DESCRIPTION
**Jira ticket :**
https://socialplus.atlassian.net/browse/PDT-2807
**Description :**
This pull request updates the `Avatar` component to improve how avatar images are displayed in the image viewer. Now, when a user taps a viewable avatar, the component ensures the large-sized version of the image is shown instead of the default size.

**Avatar image handling improvements:**

* Imported the `getFileUrlWithSize` utility to generate URLs for images at a specified size in `Avatar.tsx`.
* Updated the avatar tap handler to use the large-sized image URL when navigating to the `ImageViewer` screen, ensuring better image quality.
**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

https://github.com/user-attachments/assets/0cd6b0b5-b715-4435-bf7a-69b93428cbf8

**Note (optional) :**