### PR TITLE
fix: PDT-2788 - report post

### DIFF
--- a/src/social/hooks/queries/useFlagPost.ts
+++ b/src/social/hooks/queries/useFlagPost.ts
@@ -1,4 +1,8 @@
-import { PostRepository } from '@amityco/ts-sdk-react-native';
+import {
+  createReport,
+  deleteReport,
+  isReportedByMe,
+} from '@amityco/ts-sdk-react-native';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useToast } from '../../../core/stores/slices/toastSlice';
 import { TOAST } from '../../../core/constants';
@@ -7,14 +11,6 @@ type UseFlagPost = {
   postId: string;
   enabled?: boolean;
 };
-
-type FlagPostPayload = Awaited<ReturnType<typeof PostRepository.flagPost>>;
-
-type FlagPostParam = Parameters<typeof PostRepository.flagPost>[0];
-
-type UnflagPostPayload = Awaited<ReturnType<typeof PostRepository.unflagPost>>;
-
-type UnflagPostParam = Parameters<typeof PostRepository.unflagPost>[0];
 
 export const useFlagPost = ({ postId, enabled = true }: UseFlagPost) => {
   const { showToast } = useToast();
@@ -25,24 +21,16 @@ export const useFlagPost = ({ postId, enabled = true }: UseFlagPost) => {
     refetch,
   } = useQuery<boolean>({
     queryKey: ['PostRepository', 'isPostFlaggedByMe', postId],
-    queryFn: () => PostRepository.isPostFlaggedByMe(postId),
+    queryFn: () => isReportedByMe('post', postId),
     enabled: enabled && !!postId,
   });
 
-  const { mutate: flagPostMutate } = useMutation<
-    FlagPostPayload,
-    Error,
-    FlagPostParam
-  >({
-    mutationFn: PostRepository.flagPost,
+  const { mutate: flagPostMutate } = useMutation<boolean, Error, string>({
+    mutationFn: (targetPostId: string) => createReport('post', targetPostId),
   });
 
-  const { mutate: unflagPostMutate } = useMutation<
-    UnflagPostPayload,
-    Error,
-    UnflagPostParam
-  >({
-    mutationFn: PostRepository.unflagPost,
+  const { mutate: unflagPostMutate } = useMutation<boolean, Error, string>({
+    mutationFn: (targetPostId: string) => deleteReport('post', targetPostId),
   });
 
   const reportPost = (targetPostId: string) => {


### PR DESCRIPTION
**Jira ticket :**
https://socialplus.atlassian.net/browse/PDT-2788
**Description :**
This pull request refactors the `useFlagPost` hook to use new reporting functions from the SDK instead of the previous `PostRepository` methods. The main changes involve updating the logic for flagging, unflagging, and checking if a post is flagged by the current user.

**Migration to new reporting API:**

* Replaced `PostRepository.flagPost`, `PostRepository.unflagPost`, and `PostRepository.isPostFlaggedByMe` with `createReport`, `deleteReport`, and `isReportedByMe` respectively for handling post reports. [[1]](diffhunk://#diff-f68764343fc464528c2adb4d9fdc5b58bb439fc931846d20201da4b16046ebf3L1-R5) [[2]](diffhunk://#diff-f68764343fc464528c2adb4d9fdc5b58bb439fc931846d20201da4b16046ebf3L28-R33)
* Removed type definitions related to the old `PostRepository` methods, simplifying the hook's types.
**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

https://github.com/user-attachments/assets/a8ee2587-cbf3-460b-8ab7-f6ed4bfc0146


**Note (optional) :**
