### PR TITLE
fix: PDT-2887 - create post media icon

### DIFF
--- a/src/social/components/RenderTextWithMention/RenderTextWithMention.tsx
+++ b/src/social/components/RenderTextWithMention/RenderTextWithMention.tsx
@@ -1,4 +1,4 @@
-import { Text, Linking, TouchableOpacity } from 'react-native';
+import { Text, Linking } from 'react-native';
 import { useStyles } from './styles';
 import { memo, useCallback } from 'react';
 import { useNavigation } from '@react-navigation/native';
@@ -94,14 +94,14 @@ const RenderTextWithMention: React.FC<IrenderTextWithMention> = ({
       const nonHighlightedText = textPost.slice(currentPosition, index);
       // Add highlighted text
       const highlightedText = (
-        <TouchableOpacity
+        <Text
           onPress={() => handleOnClick(link, userId)}
           key={`highlighted-${i}`}
+          style={styles.mentionText}
+          selectable
         >
-          <Text style={styles.mentionText} selectable>
-            {textPost.slice(index, index + length)}
-          </Text>
-        </TouchableOpacity>
+          {textPost.slice(index, index + length)}
+        </Text>
       );
 
       // Update currentPosition for the next iteration

--- a/src/social/features/post/components/DetailedMediaAttachment/DetailedMediaAttachment.tsx
+++ b/src/social/features/post/components/DetailedMediaAttachment/DetailedMediaAttachment.tsx
@@ -6,7 +6,7 @@ import {
   ElementID,
   mediaAttachment,
 } from '../../../../enums';
-import { useAmityComponent } from '../../../../hooks';
+import { useAmityComponent, useAmityElement } from '../../../../hooks';
 import { useStyles } from './styles';
 import { SvgXml } from 'react-native-svg';
 import { camera, photo, video } from '../../../../../core/assets/icons';
@@ -27,6 +27,21 @@ const AmityDetailedMediaAttachmentComponent: FC<
   const { accessibilityId, themeStyles, isExcluded } = useAmityComponent({
     pageId,
     componentId,
+  });
+  const cameraElement = useAmityElement({
+    pageId,
+    componentId,
+    elementId: ElementID.camera_button,
+  });
+  const imageElement = useAmityElement({
+    pageId,
+    componentId,
+    elementId: ElementID.image_button,
+  });
+  const videoElement = useAmityElement({
+    pageId,
+    componentId,
+    elementId: ElementID.video_button,
   });
   const styles = useStyles(themeStyles);
 
@@ -64,27 +79,16 @@ const AmityDetailedMediaAttachmentComponent: FC<
     >
       <View style={styles.handleBar} />
       <View style={styles.buttonsContainer}>
-        <Pressable style={styles.mediaAttachmentBtn} onPress={onPressCamera}>
-          <View style={styles.iconContainer}>
-            <SvgXml
-              xml={camera()}
-              width={24}
-              height={24}
-              color={themeStyles?.colors?.base}
-            />
-          </View>
-          <TextKeyElement
-            pageID={pageId}
-            componentID={componentId}
-            elementID={ElementID.camera_button}
-            style={styles.iconText}
-          />
-        </Pressable>
-        {(!chosenMediaType || chosenMediaType === mediaAttachment.image) && (
-          <Pressable style={styles.mediaAttachmentBtn} onPress={onPressImage}>
+        {!cameraElement.isExcluded && (
+          <Pressable
+            testID={cameraElement.accessibilityId}
+            accessibilityLabel={cameraElement.accessibilityId}
+            style={styles.mediaAttachmentBtn}
+            onPress={onPressCamera}
+          >
             <View style={styles.iconContainer}>
               <SvgXml
-                xml={photo()}
+                xml={camera()}
                 width={24}
                 height={24}
                 color={themeStyles?.colors?.base}
@@ -93,29 +97,59 @@ const AmityDetailedMediaAttachmentComponent: FC<
             <TextKeyElement
               pageID={pageId}
               componentID={componentId}
-              elementID={ElementID.image_button}
+              elementID={ElementID.camera_button}
               style={styles.iconText}
             />
           </Pressable>
         )}
-        {(!chosenMediaType || chosenMediaType === mediaAttachment.video) && (
-          <Pressable style={styles.mediaAttachmentBtn} onPress={onPressVideo}>
-            <View style={styles.iconContainer}>
-              <SvgXml
-                xml={video()}
-                width={24}
-                height={24}
-                color={themeStyles?.colors?.base}
+        {!imageElement.isExcluded &&
+          (!chosenMediaType || chosenMediaType === mediaAttachment.image) && (
+            <Pressable
+              testID={imageElement.accessibilityId}
+              accessibilityLabel={imageElement.accessibilityId}
+              style={styles.mediaAttachmentBtn}
+              onPress={onPressImage}
+            >
+              <View style={styles.iconContainer}>
+                <SvgXml
+                  xml={photo()}
+                  width={24}
+                  height={24}
+                  color={themeStyles?.colors?.base}
+                />
+              </View>
+              <TextKeyElement
+                pageID={pageId}
+                componentID={componentId}
+                elementID={ElementID.image_button}
+                style={styles.iconText}
               />
-            </View>
-            <TextKeyElement
-              pageID={pageId}
-              componentID={componentId}
-              elementID={ElementID.video_button}
-              style={styles.iconText}
-            />
-          </Pressable>
-        )}
+            </Pressable>
+          )}
+        {!videoElement.isExcluded &&
+          (!chosenMediaType || chosenMediaType === mediaAttachment.video) && (
+            <Pressable
+              testID={videoElement.accessibilityId}
+              accessibilityLabel={videoElement.accessibilityId}
+              style={styles.mediaAttachmentBtn}
+              onPress={onPressVideo}
+            >
+              <View style={styles.iconContainer}>
+                <SvgXml
+                  xml={video()}
+                  width={24}
+                  height={24}
+                  color={themeStyles?.colors?.base}
+                />
+              </View>
+              <TextKeyElement
+                pageID={pageId}
+                componentID={componentId}
+                elementID={ElementID.video_button}
+                style={styles.iconText}
+              />
+            </Pressable>
+          )}
         {/* will use later
         <Pressable style={styles.mediaAttachmentBtn}>
           <ImageKeyElement

--- a/src/social/features/post/components/DetailedMediaAttachment/DetailedMediaAttachment.tsx
+++ b/src/social/features/post/components/DetailedMediaAttachment/DetailedMediaAttachment.tsx
@@ -8,7 +8,8 @@ import {
 } from '../../../../enums';
 import { useAmityComponent } from '../../../../hooks';
 import { useStyles } from './styles';
-import ImageKeyElement from '../../../../elements/ImageKeyElement/ImageKeyElement';
+import { SvgXml } from 'react-native-svg';
+import { camera, photo, video } from '../../../../../core/assets/icons';
 import TextKeyElement from '../../../../elements/TextKeyElement/TextKeyElement';
 
 type AmityDetailedMediaAttachmentComponentType = {
@@ -64,12 +65,14 @@ const AmityDetailedMediaAttachmentComponent: FC<
       <View style={styles.handleBar} />
       <View style={styles.buttonsContainer}>
         <Pressable style={styles.mediaAttachmentBtn} onPress={onPressCamera}>
-          <ImageKeyElement
-            pageID={pageId}
-            componentID={componentId}
-            elementID={ElementID.camera_button}
-            style={styles.iconBtn}
-          />
+          <View style={styles.iconContainer}>
+            <SvgXml
+              xml={camera()}
+              width={24}
+              height={24}
+              color={themeStyles?.colors?.base}
+            />
+          </View>
           <TextKeyElement
             pageID={pageId}
             componentID={componentId}
@@ -79,12 +82,14 @@ const AmityDetailedMediaAttachmentComponent: FC<
         </Pressable>
         {(!chosenMediaType || chosenMediaType === mediaAttachment.image) && (
           <Pressable style={styles.mediaAttachmentBtn} onPress={onPressImage}>
-            <ImageKeyElement
-              pageID={pageId}
-              componentID={componentId}
-              elementID={ElementID.image_button}
-              style={styles.iconBtn}
-            />
+            <View style={styles.iconContainer}>
+              <SvgXml
+                xml={photo()}
+                width={24}
+                height={24}
+                color={themeStyles?.colors?.base}
+              />
+            </View>
             <TextKeyElement
               pageID={pageId}
               componentID={componentId}
@@ -95,12 +100,14 @@ const AmityDetailedMediaAttachmentComponent: FC<
         )}
         {(!chosenMediaType || chosenMediaType === mediaAttachment.video) && (
           <Pressable style={styles.mediaAttachmentBtn} onPress={onPressVideo}>
-            <ImageKeyElement
-              pageID={pageId}
-              componentID={componentId}
-              elementID={ElementID.video_button}
-              style={styles.iconBtn}
-            />
+            <View style={styles.iconContainer}>
+              <SvgXml
+                xml={video()}
+                width={24}
+                height={24}
+                color={themeStyles?.colors?.base}
+              />
+            </View>
             <TextKeyElement
               pageID={pageId}
               componentID={componentId}
@@ -115,7 +122,7 @@ const AmityDetailedMediaAttachmentComponent: FC<
             pageID={pageId}
             componentID={componentId}
             elementID={ElementID.file_button}
-            style={styles.iconBtn}
+            style={styles.iconContainer}
           />
           <TextKeyElement
             pageID={pageId}

--- a/src/social/features/post/components/DetailedMediaAttachment/styles.ts
+++ b/src/social/features/post/components/DetailedMediaAttachment/styles.ts
@@ -30,10 +30,10 @@ export const useStyles = (theme: MyMD3Theme) => {
       paddingTop: 16,
       paddingHorizontal: 24,
     },
-    iconBtn: {
-      width: 24,
-      height: 24,
-      tintColor: theme.colors.base,
+    iconContainer: {
+      padding: 4,
+      borderRadius: 100,
+      backgroundColor: theme.colors.backgroundShade1,
       marginRight: 12,
     },
     iconText: {

--- a/src/social/features/post/components/MediaAttachment/MediaAttachment.tsx
+++ b/src/social/features/post/components/MediaAttachment/MediaAttachment.tsx
@@ -1,7 +1,12 @@
 import { Pressable, View, Animated, Easing } from 'react-native';
 import { FC, memo, useCallback, useEffect, useRef } from 'react';
-import { PageID, ComponentID, mediaAttachment } from '../../../../enums';
-import { useAmityComponent } from '../../../../hooks';
+import {
+  PageID,
+  ComponentID,
+  ElementID,
+  mediaAttachment,
+} from '../../../../enums';
+import { useAmityComponent, useAmityElement } from '../../../../hooks';
 import { useStyles } from './styles';
 import { SvgXml } from 'react-native-svg';
 import { camera, photo, video } from '../../../../../core/assets/icons';
@@ -24,6 +29,21 @@ const AmityMediaAttachmentComponent: FC<AmityMediaAttachmentComponentType> = ({
   const { accessibilityId, themeStyles, isExcluded } = useAmityComponent({
     pageId,
     componentId,
+  });
+  const cameraElement = useAmityElement({
+    pageId,
+    componentId,
+    elementId: ElementID.camera_button,
+  });
+  const imageElement = useAmityElement({
+    pageId,
+    componentId,
+    elementId: ElementID.image_button,
+  });
+  const videoElement = useAmityElement({
+    pageId,
+    componentId,
+    elementId: ElementID.video_button,
   });
   const styles = useStyles(themeStyles);
 
@@ -61,41 +81,57 @@ const AmityMediaAttachmentComponent: FC<AmityMediaAttachmentComponentType> = ({
     >
       <View style={styles.handleBar} />
       <View style={styles.buttonsContainer}>
-        <Pressable onPress={onPressCamera}>
-          <View style={styles.iconContainer}>
-            <SvgXml
-              xml={camera()}
-              width={24}
-              height={24}
-              color={themeStyles?.colors?.base}
-            />
-          </View>
-        </Pressable>
+        {!cameraElement.isExcluded && (
+          <Pressable
+            testID={cameraElement.accessibilityId}
+            accessibilityLabel={cameraElement.accessibilityId}
+            onPress={onPressCamera}
+          >
+            <View style={styles.iconContainer}>
+              <SvgXml
+                xml={camera()}
+                width={24}
+                height={24}
+                color={themeStyles?.colors?.base}
+              />
+            </View>
+          </Pressable>
+        )}
 
-        {(!chosenMediaType || chosenMediaType === mediaAttachment.image) && (
-          <Pressable onPress={onPressImage}>
-            <View style={styles.iconContainer}>
-              <SvgXml
-                xml={photo()}
-                width={24}
-                height={24}
-                color={themeStyles?.colors?.base}
-              />
-            </View>
-          </Pressable>
-        )}
-        {(!chosenMediaType || chosenMediaType === mediaAttachment.video) && (
-          <Pressable onPress={onPressVideo}>
-            <View style={styles.iconContainer}>
-              <SvgXml
-                xml={video()}
-                width={24}
-                height={24}
-                color={themeStyles?.colors?.base}
-              />
-            </View>
-          </Pressable>
-        )}
+        {!imageElement.isExcluded &&
+          (!chosenMediaType || chosenMediaType === mediaAttachment.image) && (
+            <Pressable
+              testID={imageElement.accessibilityId}
+              accessibilityLabel={imageElement.accessibilityId}
+              onPress={onPressImage}
+            >
+              <View style={styles.iconContainer}>
+                <SvgXml
+                  xml={photo()}
+                  width={24}
+                  height={24}
+                  color={themeStyles?.colors?.base}
+                />
+              </View>
+            </Pressable>
+          )}
+        {!videoElement.isExcluded &&
+          (!chosenMediaType || chosenMediaType === mediaAttachment.video) && (
+            <Pressable
+              testID={videoElement.accessibilityId}
+              accessibilityLabel={videoElement.accessibilityId}
+              onPress={onPressVideo}
+            >
+              <View style={styles.iconContainer}>
+                <SvgXml
+                  xml={video()}
+                  width={24}
+                  height={24}
+                  color={themeStyles?.colors?.base}
+                />
+              </View>
+            </Pressable>
+          )}
         {/* //will use later
         <Pressable>
           <ImageKeyElement

--- a/src/social/features/post/components/MediaAttachment/MediaAttachment.tsx
+++ b/src/social/features/post/components/MediaAttachment/MediaAttachment.tsx
@@ -1,14 +1,10 @@
 import { Pressable, View, Animated, Easing } from 'react-native';
 import { FC, memo, useCallback, useEffect, useRef } from 'react';
-import {
-  PageID,
-  ComponentID,
-  ElementID,
-  mediaAttachment,
-} from '../../../../enums';
+import { PageID, ComponentID, mediaAttachment } from '../../../../enums';
 import { useAmityComponent } from '../../../../hooks';
 import { useStyles } from './styles';
-import ImageKeyElement from '../../../../elements/ImageKeyElement/ImageKeyElement';
+import { SvgXml } from 'react-native-svg';
+import { camera, photo, video } from '../../../../../core/assets/icons';
 
 type AmityMediaAttachmentComponentType = {
   onPressCamera: () => void;
@@ -66,32 +62,38 @@ const AmityMediaAttachmentComponent: FC<AmityMediaAttachmentComponentType> = ({
       <View style={styles.handleBar} />
       <View style={styles.buttonsContainer}>
         <Pressable onPress={onPressCamera}>
-          <ImageKeyElement
-            pageID={pageId}
-            componentID={componentId}
-            elementID={ElementID.camera_button}
-            style={styles.iconBtn}
-          />
+          <View style={styles.iconContainer}>
+            <SvgXml
+              xml={camera()}
+              width={24}
+              height={24}
+              color={themeStyles?.colors?.base}
+            />
+          </View>
         </Pressable>
 
         {(!chosenMediaType || chosenMediaType === mediaAttachment.image) && (
           <Pressable onPress={onPressImage}>
-            <ImageKeyElement
-              pageID={pageId}
-              componentID={componentId}
-              elementID={ElementID.image_button}
-              style={styles.iconBtn}
-            />
+            <View style={styles.iconContainer}>
+              <SvgXml
+                xml={photo()}
+                width={24}
+                height={24}
+                color={themeStyles?.colors?.base}
+              />
+            </View>
           </Pressable>
         )}
         {(!chosenMediaType || chosenMediaType === mediaAttachment.video) && (
           <Pressable onPress={onPressVideo}>
-            <ImageKeyElement
-              pageID={pageId}
-              componentID={componentId}
-              elementID={ElementID.video_button}
-              style={styles.iconBtn}
-            />
+            <View style={styles.iconContainer}>
+              <SvgXml
+                xml={video()}
+                width={24}
+                height={24}
+                color={themeStyles?.colors?.base}
+              />
+            </View>
           </Pressable>
         )}
         {/* //will use later
@@ -100,7 +102,7 @@ const AmityMediaAttachmentComponent: FC<AmityMediaAttachmentComponentType> = ({
             pageID={pageId}
             componentID={componentId}
             elementID={ElementID.file_button}
-            style={styles.iconBtn}
+            style={styles.iconContainer}
           />
         </Pressable> */}
       </View>

--- a/src/social/features/post/components/MediaAttachment/styles.ts
+++ b/src/social/features/post/components/MediaAttachment/styles.ts
@@ -33,10 +33,10 @@ export const useStyles = (theme: MyMD3Theme) => {
       width: '100%',
       justifyContent: 'space-around',
     },
-    iconBtn: {
-      width: 24,
-      height: 24,
-      tintColor: theme.colors.base,
+    iconContainer: {
+      padding: 4,
+      borderRadius: 100,
+      backgroundColor: theme.colors.backgroundShade1,
     },
   });
 


### PR DESCRIPTION
**Jira ticket :**
https://socialplus.atlassian.net/browse/PDT-2887
**Description :**
This pull request updates the UI for media attachment buttons in the social post components to use SVG icons instead of the previous `ImageKeyElement` component, and refines the styling for these icons. Additionally, it simplifies the mention rendering logic. The main changes can be grouped as follows:

**UI Refactoring for Media Attachment Buttons:**

* Replaced `ImageKeyElement` with `SvgXml` for camera, photo, and video icons in both `DetailedMediaAttachment` and `MediaAttachment` components, using SVG assets for consistent and scalable icon rendering. [[1]](diffhunk://#diff-4890e129be15efc4e3ccb20fe829a42f7470680b8ac59a405bf824411ca2a77cL11-R12) [[2]](diffhunk://#diff-4890e129be15efc4e3ccb20fe829a42f7470680b8ac59a405bf824411ca2a77cL67-R75) [[3]](diffhunk://#diff-4890e129be15efc4e3ccb20fe829a42f7470680b8ac59a405bf824411ca2a77cL82-R92) [[4]](diffhunk://#diff-4890e129be15efc4e3ccb20fe829a42f7470680b8ac59a405bf824411ca2a77cL98-R110) [[5]](diffhunk://#diff-82b069b70ea97d1bfee9a14e6c320a842d6d9b6a3d74272d05f8992c7ca82bbcL3-R7) [[6]](diffhunk://#diff-82b069b70ea97d1bfee9a14e6c320a842d6d9b6a3d74272d05f8992c7ca82bbcL69-R96)
* Updated the icon container styling in `styles.ts` files to add padding, rounded backgrounds, and improved visual consistency for icon buttons. [[1]](diffhunk://#diff-5619a8256fb1d25f8a24a823651bb79ff9a55e4c0dffd157ec12d86e0ea83194L33-R36) [[2]](diffhunk://#diff-4b85ff81c9f956c55cc8e3ae03c25dd0e66f37398d1cd937832c1aba9b2f7df9L36-R39)
* Adjusted the styling prop for the file button to use the new `iconContainer` style. [[1]](diffhunk://#diff-4890e129be15efc4e3ccb20fe829a42f7470680b8ac59a405bf824411ca2a77cL118-R125) [[2]](diffhunk://#diff-82b069b70ea97d1bfee9a14e6c320a842d6d9b6a3d74272d05f8992c7ca82bbcL103-R105)

**Mention Rendering Simplification:**

* Simplified the mention rendering in `RenderTextWithMention.tsx` by removing the unnecessary `TouchableOpacity` wrapper and directly using a styled `Text` component for mentions, improving accessibility and reducing component complexity. [[1]](diffhunk://#diff-d40d06abf9e3c0ff9da9ca0fdd15efb62db6e57ee6373020ceb95ad1374e9e6bL1-R1) [[2]](diffhunk://#diff-d40d06abf9e3c0ff9da9ca0fdd15efb62db6e57ee6373020ceb95ad1374e9e6bL97-L104)

These changes collectively improve the maintainability, scalability, and visual consistency of the media attachment and mention UI components.
**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

https://github.com/user-attachments/assets/1a8fe7e1-e7ce-4fbb-9ad4-e5cb483cf600


**Note (optional) :**
