### PR TITLE
fix: PDT-2855 - delete comment confirm

### DIFF
--- a/src/social/components/Social/ReplyCommentList/index.tsx
+++ b/src/social/components/Social/ReplyCommentList/index.tsx
@@ -12,10 +12,12 @@ import {
 import { useStyles } from './styles';
 import { SvgXml } from 'react-native-svg';
 import {
+  editIcon,
   expandIcon,
   likedXml,
   likeXml,
   personXml,
+  storyDraftDeletHyperLink,
   threeDots,
 } from '../../../../core/assets/icons/xml';
 
@@ -139,22 +141,18 @@ export default function ReplyCommentList({
       await addCommentReaction(commentId, 'like');
     }
   };
-  const deletePostObject = () => {
-    Alert.alert(
-      'Delete this post',
-      `This post will be permanently deleted. You'll no longer see and find this post`,
-      [
-        {
-          text: 'Cancel',
-          style: 'cancel',
-        },
-        {
-          text: 'Delete',
-          style: 'destructive',
-          onPress: () => onDelete && onDelete(commentId),
-        },
-      ]
-    );
+  const deleteReplyComment = () => {
+    Alert.alert('Delete reply', 'This reply will be permanently deleted.', [
+      {
+        text: 'Cancel',
+        style: 'cancel',
+      },
+      {
+        text: 'Delete',
+        style: 'destructive',
+        onPress: () => onDelete && onDelete(commentId),
+      },
+    ]);
     setIsVisible(false);
   };
   const reportCommentObject = async () => {
@@ -296,13 +294,23 @@ export default function ReplyCommentList({
                   onPress={openEditCommentModal}
                   style={styles.modalRow}
                 >
-                  <Text style={styles.deleteText}> Edit Comment</Text>
+                  <SvgXml
+                    xml={editIcon(theme.colors.base)}
+                    width="20"
+                    height="20"
+                  />
+                  <Text style={styles.deleteText}> Edit reply</Text>
                 </TouchableOpacity>
                 <TouchableOpacity
-                  onPress={deletePostObject}
+                  onPress={deleteReplyComment}
                   style={styles.modalRow}
                 >
-                  <Text style={styles.deleteText}> Delete Comment</Text>
+                  <SvgXml
+                    xml={storyDraftDeletHyperLink()}
+                    width="20"
+                    height="20"
+                  />
+                  <Text style={styles.deleteText}> Delete reply</Text>
                 </TouchableOpacity>
               </View>
             ) : (

--- a/src/social/features/comment/components/PostComment/CommentListItem/CommentListItem.tsx
+++ b/src/social/features/comment/components/PostComment/CommentListItem/CommentListItem.tsx
@@ -245,22 +245,18 @@ const CommentListItem = ({
     }
   };
 
-  const deletePostObject = () => {
-    Alert.alert(
-      'Delete this post',
-      `This post will be permanently deleted. You'll no longer see and find this post`,
-      [
-        {
-          text: 'Cancel',
-          style: 'cancel',
-        },
-        {
-          text: 'Delete',
-          style: 'destructive',
-          onPress: () => onDelete && onDelete(commentId),
-        },
-      ]
-    );
+  const deleteComment = () => {
+    Alert.alert('Delete comment', 'This comment will be permanently deleted.', [
+      {
+        text: 'Cancel',
+        style: 'cancel',
+      },
+      {
+        text: 'Delete',
+        style: 'destructive',
+        onPress: () => onDelete && onDelete(commentId),
+      },
+    ]);
     setIsVisible(false);
   };
   const reportCommentObject = async () => {
@@ -518,7 +514,7 @@ const CommentListItem = ({
                   <Text style={styles.deleteText}> Edit Comment</Text>
                 </TouchableOpacity>
                 <TouchableOpacity
-                  onPress={deletePostObject}
+                  onPress={deleteComment}
                   style={styles.modalRow}
                 >
                   <SvgXml

--- a/src/social/features/comment/components/PostComment/ReplyCommentList/index.tsx
+++ b/src/social/features/comment/components/PostComment/ReplyCommentList/index.tsx
@@ -12,10 +12,12 @@ import {
 import { useStyles } from './styles';
 import { SvgXml } from 'react-native-svg';
 import {
+  editIcon,
   expandIcon,
   likeCircle,
   personXml,
   reportOutLine,
+  storyDraftDeletHyperLink,
   threeDots,
 } from '../../../../../../core/assets/icons/xml';
 import type { UserInterface } from '../../../../../../core/types';
@@ -144,22 +146,18 @@ const ReplyCommentList = ({
       await addCommentReaction(commentId, 'like');
     }
   };
-  const deletePostObject = () => {
-    Alert.alert(
-      'Delete this post',
-      `This post will be permanently deleted. You'll no longer see and find this post`,
-      [
-        {
-          text: 'Cancel',
-          style: 'cancel',
-        },
-        {
-          text: 'Delete',
-          style: 'destructive',
-          onPress: () => onDelete && onDelete(commentId),
-        },
-      ]
-    );
+  const deleteReplyComment = () => {
+    Alert.alert('Delete reply', 'This reply will be permanently deleted.', [
+      {
+        text: 'Cancel',
+        style: 'cancel',
+      },
+      {
+        text: 'Delete',
+        style: 'destructive',
+        onPress: () => onDelete && onDelete(commentId),
+      },
+    ]);
     setIsVisible(false);
   };
   const reportCommentObject = async () => {
@@ -357,13 +355,23 @@ const ReplyCommentList = ({
                   onPress={openEditCommentModal}
                   style={styles.modalRow}
                 >
-                  <Text style={styles.deleteText}> Edit Comment</Text>
+                  <SvgXml
+                    xml={editIcon(theme.colors.base)}
+                    width="20"
+                    height="20"
+                  />
+                  <Text style={styles.deleteText}> Edit reply</Text>
                 </TouchableOpacity>
                 <TouchableOpacity
-                  onPress={deletePostObject}
+                  onPress={deleteReplyComment}
                   style={styles.modalRow}
                 >
-                  <Text style={styles.deleteText}> Delete Comment</Text>
+                  <SvgXml
+                    xml={storyDraftDeletHyperLink()}
+                    width="20"
+                    height="20"
+                  />
+                  <Text style={styles.deleteText}> Delete reply</Text>
                 </TouchableOpacity>
               </View>
             ) : (

--- a/src/social/features/comment/components/PostComment/ReplyCommentList/index.tsx
+++ b/src/social/features/comment/components/PostComment/ReplyCommentList/index.tsx
@@ -385,7 +385,7 @@ const ReplyCommentList = ({
                   height="20"
                 />
                 <Text style={styles.deleteText}>
-                  {isReportByMe ? 'Unreport comment' : 'Report comment'}
+                  {isReportByMe ? 'Unreport reply' : 'Report reply'}
                 </Text>
               </TouchableOpacity>
             )}


### PR DESCRIPTION
**Jira ticket :**
https://socialplus.atlassian.net/browse/PDT-2855
**Description :**
This pull request refines the UI and UX for comment and reply actions in the social features by standardizing delete and edit dialogs, updating icon usage, and clarifying action labels. The changes ensure consistency between comment and reply modals, improve visual cues with icons, and provide clearer messaging to users.

**UI/UX Improvements for Comment and Reply Actions:**

* Changed the delete confirmation dialogs for comments and replies to use more concise and context-appropriate titles and messages, and standardized the function names (`deleteComment`, `deleteReplyComment`) for clarity. [[1]](diffhunk://#diff-1af5ff592b283cf0571e1383f7829bc311c05f38ff988044b5dcc65fc28ee2e0L142-R145) [[2]](diffhunk://#diff-1af5ff592b283cf0571e1383f7829bc311c05f38ff988044b5dcc65fc28ee2e0L156-R155) [[3]](diffhunk://#diff-62a7218f42b7b98742546262a4c5c5c5ccf1dafa0085abcafce703e75124e819L248-R249) [[4]](diffhunk://#diff-62a7218f42b7b98742546262a4c5c5c5ccf1dafa0085abcafce703e75124e819L262-R259) [[5]](diffhunk://#diff-93f5787a66d17e772be524a096ed96d7a4da52ccd9bee4809feb04adaa51f6afL147-R150) [[6]](diffhunk://#diff-93f5787a66d17e772be524a096ed96d7a4da52ccd9bee4809feb04adaa51f6afL161-R160)
* Updated the edit and delete modal options for both comments and replies to include relevant SVG icons (`editIcon`, `storyDraftDeletHyperLink`) and changed the text to "Edit reply" and "Delete reply" for replies, improving visual clarity and consistency. [[1]](diffhunk://#diff-1af5ff592b283cf0571e1383f7829bc311c05f38ff988044b5dcc65fc28ee2e0L299-R313) [[2]](diffhunk://#diff-62a7218f42b7b98742546262a4c5c5c5ccf1dafa0085abcafce703e75124e819L521-R517) [[3]](diffhunk://#diff-93f5787a66d17e772be524a096ed96d7a4da52ccd9bee4809feb04adaa51f6afL360-R374)

**Code Consistency and Cleanup:**

* Updated imports to include the new icons (`editIcon`, `storyDraftDeletHyperLink`) where necessary. [[1]](diffhunk://#diff-1af5ff592b283cf0571e1383f7829bc311c05f38ff988044b5dcc65fc28ee2e0R15-R20) [[2]](diffhunk://#diff-93f5787a66d17e772be524a096ed96d7a4da52ccd9bee4809feb04adaa51f6afR15-R20)
* Replaced old function names and removed unused code related to the previous delete dialog implementation. [[1]](diffhunk://#diff-1af5ff592b283cf0571e1383f7829bc311c05f38ff988044b5dcc65fc28ee2e0L142-R145) [[2]](diffhunk://#diff-62a7218f42b7b98742546262a4c5c5c5ccf1dafa0085abcafce703e75124e819L248-R249) [[3]](diffhunk://#diff-93f5787a66d17e772be524a096ed96d7a4da52ccd9bee4809feb04adaa51f6afL147-R150)

These changes collectively enhance the user experience by making destructive actions clearer and more consistent, and by improving the visual feedback provided to users.
**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

https://github.com/user-attachments/assets/274e5a7a-1f52-4c59-a6d2-dbc9fa5924c9


**Note (optional) :**
