### PR TITLE
fix: PDT-2738 - navigate from avatar

### DIFF
--- a/src/social/components/legacy/Social/PostList/index.tsx
+++ b/src/social/components/legacy/Social/PostList/index.tsx
@@ -406,23 +406,25 @@ export default function PostList({ postDetail, onDelete }: IPostList) {
     <View key={postId} style={styles.postWrap}>
       <View style={styles.headerSection}>
         <View style={styles.user}>
-          {user?.avatarCustomUrl ? (
-            <Image
-              style={styles.avatar as ImageStyle}
-              source={{ uri: user.avatarCustomUrl }}
-            />
-          ) : user?.avatarFileId ? (
-            <Image
-              style={styles.avatar as ImageStyle}
-              source={{
-                uri: `https://api.${apiRegion}.amity.co/api/v3/files/${user.avatarFileId}/download`,
-              }}
-            />
-          ) : (
-            <View style={styles.avatar}>
-              <SvgXml xml={personXml} width="20" height="16" />
-            </View>
-          )}
+          <TouchableOpacity onPress={handleDisplayNamePress}>
+            {user?.avatarCustomUrl ? (
+              <Image
+                style={styles.avatar as ImageStyle}
+                source={{ uri: user.avatarCustomUrl }}
+              />
+            ) : user?.avatarFileId ? (
+              <Image
+                style={styles.avatar as ImageStyle}
+                source={{
+                  uri: `https://api.${apiRegion}.amity.co/api/v3/files/${user.avatarFileId}/download`,
+                }}
+              />
+            ) : (
+              <View style={styles.avatar}>
+                <SvgXml xml={personXml} width="20" height="16" />
+              </View>
+            )}
+          </TouchableOpacity>
 
           <View style={styles.fillSpace}>
             <View style={styles.headerRow}>

--- a/src/social/components/legacy/Social/PostList/index.tsx
+++ b/src/social/components/legacy/Social/PostList/index.tsx
@@ -406,31 +406,57 @@ export default function PostList({ postDetail, onDelete }: IPostList) {
     <View key={postId} style={styles.postWrap}>
       <View style={styles.headerSection}>
         <View style={styles.user}>
-          <TouchableOpacity onPress={handleDisplayNamePress}>
-            {user?.avatarCustomUrl ? (
-              <Image
-                style={styles.avatar as ImageStyle}
-                source={{ uri: user.avatarCustomUrl }}
-              />
-            ) : user?.avatarFileId ? (
-              <Image
-                style={styles.avatar as ImageStyle}
-                source={{
-                  uri: `https://api.${apiRegion}.amity.co/api/v3/files/${user.avatarFileId}/download`,
-                }}
-              />
-            ) : (
-              <View style={styles.avatar}>
-                <SvgXml xml={personXml} width="20" height="16" />
-              </View>
-            )}
-          </TouchableOpacity>
+          {user?.userId ? (
+            <TouchableOpacity onPress={handleDisplayNamePress}>
+              {user?.avatarCustomUrl ? (
+                <Image
+                  style={styles.avatar as ImageStyle}
+                  source={{ uri: user.avatarCustomUrl }}
+                />
+              ) : user?.avatarFileId ? (
+                <Image
+                  style={styles.avatar as ImageStyle}
+                  source={{
+                    uri: `https://api.${apiRegion}.amity.co/api/v3/files/${user.avatarFileId}/download`,
+                  }}
+                />
+              ) : (
+                <View style={styles.avatar}>
+                  <SvgXml xml={personXml} width="20" height="16" />
+                </View>
+              )}
+            </TouchableOpacity>
+          ) : (
+            <>
+              {user?.avatarCustomUrl ? (
+                <Image
+                  style={styles.avatar as ImageStyle}
+                  source={{ uri: user.avatarCustomUrl }}
+                />
+              ) : user?.avatarFileId ? (
+                <Image
+                  style={styles.avatar as ImageStyle}
+                  source={{
+                    uri: `https://api.${apiRegion}.amity.co/api/v3/files/${user.avatarFileId}/download`,
+                  }}
+                />
+              ) : (
+                <View style={styles.avatar}>
+                  <SvgXml xml={personXml} width="20" height="16" />
+                </View>
+              )}
+            </>
+          )}
 
           <View style={styles.fillSpace}>
             <View style={styles.headerRow}>
-              <TouchableOpacity onPress={handleDisplayNamePress}>
+              {user?.userId ? (
+                <TouchableOpacity onPress={handleDisplayNamePress}>
+                  <Text style={styles.headerText}>{user?.displayName}</Text>
+                </TouchableOpacity>
+              ) : (
                 <Text style={styles.headerText}>{user?.displayName}</Text>
-              </TouchableOpacity>
+              )}
 
               {communityName && (
                 <View style={styles.communityNameContainer}>

--- a/src/social/features/post/components/Content/Content.tsx
+++ b/src/social/features/post/components/Content/Content.tsx
@@ -179,12 +179,23 @@ const AmityPostContentComponent: FC<AmityPostContentComponentProps> = ({
       >
         <Pressable style={styles.headerSection} onPress={onPressPost}>
           <View style={styles.user}>
-            <TouchableOpacity
-              onPress={(e) => {
-                e.stopPropagation();
-                handleDisplayNamePress();
-              }}
-            >
+            {creator?.userId ? (
+              <TouchableOpacity
+                onPress={(e) => {
+                  e.stopPropagation();
+                  handleDisplayNamePress();
+                }}
+              >
+                <AvatarElement
+                  style={styles.avatar as ImageStyle}
+                  avatarId={creator?.avatarFileId}
+                  pageID={pageId}
+                  elementID={ElementID.WildCardElement}
+                  componentID={componentId}
+                  avatarCustomUrl={creator?.avatarCustomUrl}
+                />
+              </TouchableOpacity>
+            ) : (
               <AvatarElement
                 style={styles.avatar as ImageStyle}
                 avatarId={creator?.avatarFileId}
@@ -193,7 +204,7 @@ const AmityPostContentComponent: FC<AmityPostContentComponentProps> = ({
                 componentID={componentId}
                 avatarCustomUrl={creator?.avatarCustomUrl}
               />
-            </TouchableOpacity>
+            )}
 
             <View style={styles.fillSpace}>
               <View style={styles.headerRow}>

--- a/src/social/features/post/components/Content/Content.tsx
+++ b/src/social/features/post/components/Content/Content.tsx
@@ -179,14 +179,21 @@ const AmityPostContentComponent: FC<AmityPostContentComponentProps> = ({
       >
         <Pressable style={styles.headerSection} onPress={onPressPost}>
           <View style={styles.user}>
-            <AvatarElement
-              style={styles.avatar as ImageStyle}
-              avatarId={creator?.avatarFileId}
-              pageID={pageId}
-              elementID={ElementID.WildCardElement}
-              componentID={componentId}
-              avatarCustomUrl={creator?.avatarCustomUrl}
-            />
+            <TouchableOpacity
+              onPress={(e) => {
+                e.stopPropagation();
+                handleDisplayNamePress();
+              }}
+            >
+              <AvatarElement
+                style={styles.avatar as ImageStyle}
+                avatarId={creator?.avatarFileId}
+                pageID={pageId}
+                elementID={ElementID.WildCardElement}
+                componentID={componentId}
+                avatarCustomUrl={creator?.avatarCustomUrl}
+              />
+            </TouchableOpacity>
 
             <View style={styles.fillSpace}>
               <View style={styles.headerRow}>


### PR DESCRIPTION
**Jira ticket :**
https://socialplus.atlassian.net/browse/PDT-2738

**Description :**
This pull request updates the avatar UI in post lists and post content components to improve navigation and user interaction. The main change is making the user avatar clickable, allowing users to trigger the `handleDisplayNamePress` action when tapping the avatar, without interfering with other touch events.

**User interaction improvements:**

* Wrapped the user avatar in a `TouchableOpacity` in `PostList` (`src/social/components/legacy/Social/PostList/index.tsx`), so tapping the avatar now triggers `handleDisplayNamePress`. [[1]](diffhunk://#diff-fe6aa9e4715973d9060b465f851778dc950d899aeceea089ee69d63cdf44d9f0R409) [[2]](diffhunk://#diff-fe6aa9e4715973d9060b465f851778dc950d899aeceea089ee69d63cdf44d9f0R427)
* Wrapped the avatar in `Content.tsx` (`src/social/features/post/components/Content/Content.tsx`) with a `TouchableOpacity` that stops event propagation and calls `handleDisplayNamePress`, ensuring that tapping the avatar does not trigger the parent `Pressable`'s `onPressPost`. [[1]](diffhunk://#diff-6734d2a480656558eb30342d7d6bca9e92d1b6a43840b0ec2f86cca507d9b703R182-R187) [[2]](diffhunk://#diff-6734d2a480656558eb30342d7d6bca9e92d1b6a43840b0ec2f86cca507d9b703R196)
**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

https://github.com/user-attachments/assets/761240d4-b45f-4a9e-aff9-910161dfb13b


**Note (optional) :**
