### PR TITLE
fix: PDT-2739 -  disable display name when not allowed

### DIFF
--- a/src/social/components/FormInput/FormInput.tsx
+++ b/src/social/components/FormInput/FormInput.tsx
@@ -24,6 +24,7 @@ function FormInput({
   pageId = PageID.WildCardPage,
   elementId = ElementID.WildCardElement,
   componentId = ComponentID.WildCardComponent,
+  editable = true,
   ...props
 }: FormInputProps) {
   const { styles, theme } = useStyles();
@@ -46,7 +47,8 @@ function FormInput({
       <TextInput
         {...props}
         value={value}
-        style={styles.input}
+        editable={editable}
+        style={[styles.input, !editable && styles.inputDisabled]}
         maxLength={maxLength}
         placeholderTextColor={theme.colors.baseShade3}
       />

--- a/src/social/components/FormInput/styles.ts
+++ b/src/social/components/FormInput/styles.ts
@@ -26,6 +26,9 @@ export const useStyles = () => {
       padding: 0,
       margin: 0,
     },
+    inputDisabled: {
+      color: theme.colors.baseShade2,
+    },
   });
 
   return {

--- a/src/social/features/user/Edit/Edit.tsx
+++ b/src/social/features/user/Edit/Edit.tsx
@@ -23,6 +23,7 @@ export function EditUser({ userId }: EditUserProps) {
     isSubmitting,
     handleSubmit,
     accessibilityId,
+    isDisplayNameDisabled,
   } = useEditUser(userId);
 
   return (
@@ -54,6 +55,7 @@ export function EditUser({ userId }: EditUserProps) {
                   pageId={PageID.edit_user_profile_page}
                   maxLength={CHARACTER_LIMIT.USER_DISPLAY_NAME}
                   elementId={ElementID.user_display_name_title}
+                  editable={!isDisplayNameDisabled}
                 />
               )}
             />

--- a/src/social/features/user/Edit/hooks/useEditUser.ts
+++ b/src/social/features/user/Edit/hooks/useEditUser.ts
@@ -12,6 +12,7 @@ import { useToast } from '../../../../../core/stores/slices/toastSlice';
 import { ERROR_CODE } from '../../../../../core/constants';
 import { PageID } from '../../../../enums';
 import { useAmityPage } from '../../../../hooks';
+import { useState } from 'react';
 
 const schema = z.object({
   image: z.custom<Amity.File<'image'>>().optional(),
@@ -35,6 +36,7 @@ export const useEditUser = (userId: string) => {
   const navigation =
     useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   const { showToast } = useToast();
+  const [isDisplayNameDisabled, setIsDisplayNameDisabled] = useState(false);
 
   const {
     watch,
@@ -67,6 +69,7 @@ export const useEditUser = (userId: string) => {
     },
     onError: (error) => {
       if (error.message?.includes(ERROR_CODE.DISPLAY_NAME_UPDATE)) {
+        setIsDisplayNameDisabled(true);
         showToast({
           type: 'informative',
           message: 'Only administrator can update user display name.',
@@ -83,7 +86,7 @@ export const useEditUser = (userId: string) => {
   const onSubmit = async (data: EditUserFormValues) => {
     await mutateAsync({
       avatarFileId: data.image?.fileId,
-      displayName: data.displayName,
+      ...(isDisplayNameDisabled ? {} : { displayName: data.displayName }),
       description: data.description,
     });
   };
@@ -100,5 +103,6 @@ export const useEditUser = (userId: string) => {
     isValid,
     onSubmit,
     accessibilityId,
+    isDisplayNameDisabled,
   };
 };

--- a/src/social/features/user/Edit/hooks/useEditUser.ts
+++ b/src/social/features/user/Edit/hooks/useEditUser.ts
@@ -41,6 +41,7 @@ export const useEditUser = (userId: string) => {
   const {
     watch,
     control,
+    resetField,
     handleSubmit,
     formState: { isDirty, isSubmitting, isValid },
   } = useForm<EditUserFormValues>({
@@ -70,6 +71,7 @@ export const useEditUser = (userId: string) => {
     onError: (error) => {
       if (error.message?.includes(ERROR_CODE.DISPLAY_NAME_UPDATE)) {
         setIsDisplayNameDisabled(true);
+        resetField('displayName');
         showToast({
           type: 'informative',
           message: 'Only administrator can update user display name.',


### PR DESCRIPTION
**Jira ticket :**
https://socialplus.atlassian.net/browse/PDT-2739

**Description :**
This pull request introduces a new mechanism to disable editing of the user display name in the user profile editing flow if the backend returns a specific error. It updates the `FormInput` component to support a disabled state, applies conditional logic in the user editing form, and ensures the UI reflects when the display name field is not editable.

**User Profile Editing Improvements:**

* Added logic in `useEditUser` hook to disable the display name field (`isDisplayNameDisabled`) when the backend returns a `DISPLAY_NAME_UPDATE` error, and reset the field value accordingly. The form now prevents further display name submissions in this state. [[1]](diffhunk://#diff-ea140449aac7e73afb80aba0a1bedf68852d346422dbaf4db53b8257f23a676cR39-R44) [[2]](diffhunk://#diff-ea140449aac7e73afb80aba0a1bedf68852d346422dbaf4db53b8257f23a676cR73-R74) [[3]](diffhunk://#diff-ea140449aac7e73afb80aba0a1bedf68852d346422dbaf4db53b8257f23a676cL86-R91) [[4]](diffhunk://#diff-ea140449aac7e73afb80aba0a1bedf68852d346422dbaf4db53b8257f23a676cR108)
* Updated `EditUser` component to pass the `editable` prop to `FormInput` for the display name field, using the new `isDisplayNameDisabled` flag. [[1]](diffhunk://#diff-fe3de13dffec81d4352c376e2cdd8435e707f615e4797d88819fdc219c6421e4R26) [[2]](diffhunk://#diff-fe3de13dffec81d4352c376e2cdd8435e707f615e4797d88819fdc219c6421e4R58)

**FormInput Component Enhancements:**

* Added an `editable` prop to `FormInput` and passed it to the underlying `TextInput`. The component now visually and functionally supports a disabled state. [[1]](diffhunk://#diff-825603093578e37c45593d05e38529191e58cd12f4d81d59c97eb77062d3b067R27) [[2]](diffhunk://#diff-825603093578e37c45593d05e38529191e58cd12f4d81d59c97eb77062d3b067L49-R51)
* Introduced a new `inputDisabled` style in the `FormInput` styles to visually indicate when the input is disabled.
**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

https://github.com/user-attachments/assets/88eb29d6-8d53-47e6-841a-1b90ce90af74


**Note (optional) :**
