### PR TITLE
fix: PDT-2983 - create story app crash

### DIFF
--- a/src/social/features/story/Draft/Draft.tsx
+++ b/src/social/features/story/Draft/Draft.tsx
@@ -115,10 +115,14 @@ const AmityDraftStoryPage: FC<IAmityDraftStoryPage> = ({
 
   const onPressShareStory = useCallback(async () => {
     const formData = new FormData();
+    const isImage = type === StoryType.image;
+    const mimeType =
+      mime.getType(mediaType.uri) ?? (isImage ? 'image/jpeg' : 'video/mp4');
     formData.append('files', {
-      ...mediaType,
-      type: mime.getType(mediaType.uri),
-    });
+      uri: mediaType.uri,
+      name: mediaType.name,
+      type: mimeType,
+    } as unknown as Blob);
 
     try {
       setLoading(true);
@@ -204,9 +208,9 @@ const AmityDraftStoryPage: FC<IAmityDraftStoryPage> = ({
         >
           <SvgXml xml={storyHyperLinkIcon('blue')} width="25" height="25" />
           <Text style={styles.hyperlinkText}>
-            {hyperlink[0].data.customText.length === 0
-              ? hyperlink[0].data.url
-              : hyperlink[0].data.customText}
+            {(hyperlink[0]?.data?.customText?.length ?? 0) === 0
+              ? hyperlink[0]?.data?.url
+              : hyperlink[0]?.data?.customText}
           </Text>
         </TouchableOpacity>
       )}

--- a/src/social/features/story/Draft/styles.ts
+++ b/src/social/features/story/Draft/styles.ts
@@ -97,7 +97,7 @@ export const useStyles = () => {
     hyperLinkIcon: {
       width: 32,
       height: 32,
-      tintColor: theme.colors.primary,
+      color: theme.colors.primary,
     },
     handleBar: {
       width: 36,


### PR DESCRIPTION
**Jira ticket :**
https://socialplus.atlassian.net/browse/PDT-2983
**Description :**
This pull request makes several improvements to the `Draft` story feature, mainly focusing on better handling of media uploads, safer rendering of hyperlinks, and a minor style adjustment. The key changes are grouped below:

**Media Upload Handling:**

* Improved the way the media file's MIME type is determined when sharing a story, ensuring the correct type is set for both images and videos. This helps prevent upload issues due to incorrect file types.

**Hyperlink Rendering Robustness:**

* Updated the logic for displaying hyperlink text to safely handle cases where the hyperlink data may be missing or undefined, preventing potential runtime errors.

**Style Adjustment:**

* Changed the `hyperLinkIcon` style property from `tintColor` to `color` to align with the expected style usage for the icon component.
**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

https://github.com/user-attachments/assets/b33e1c0e-540a-47ed-a0fc-b4b831fa21a7


**Note (optional) :**
