### PR TITLE
fix: PDT-2982 - poll date picker

### DIFF
--- a/src/social/features/poll/Composer/components/PollDurationBottomSheet.tsx
+++ b/src/social/features/poll/Composer/components/PollDurationBottomSheet.tsx
@@ -87,12 +87,14 @@ export function AndroidBottomSheet() {
   return (
     <View style={{ paddingBottom: bottom + 8 }}>
       {androidDurationOptions.map((option) => {
-        const isSelected =
-          duration.value === option.value && duration.label === option.label;
+        const isSelected = duration.value === option.value;
         return (
           <TouchableOpacity
             key={option.label}
             style={styles.androidDurationOption}
+            accessibilityRole="radio"
+            accessibilityState={{ selected: isSelected }}
+            accessibilityLabel={option.label}
             onPress={() => {
               setDuration(option);
               bottomSheetRef.current?.close();

--- a/src/social/features/poll/Composer/components/PollDurationBottomSheet.tsx
+++ b/src/social/features/poll/Composer/components/PollDurationBottomSheet.tsx
@@ -1,6 +1,11 @@
 import { View, TouchableOpacity } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { SvgXml } from 'react-native-svg';
-import { arrowRight } from '../../../../../core/assets/icons';
+import {
+  arrowRight,
+  radioChecked,
+  radioUnchecked,
+} from '../../../../../core/assets/icons';
 import { Radio } from '../../../../../core/components/Radio';
 import { Typography } from '../../../../../core/components/Typography/Typography';
 import { IOSPollDurationPicker } from './PollDurationPicker';
@@ -70,31 +75,43 @@ export function IOSBottomSheet() {
   );
 }
 
+// Android: Pressable is unreliable inside @devvie/bottom-sheet's PanResponder-
+// controlled Animated.View — touches are intercepted before reaching Pressable.
+// Use TouchableOpacity rows with explicit radio SVG icons instead.
 export function AndroidBottomSheet() {
-  const { styles } = useStyles();
+  const { styles, theme } = useStyles();
+  const { bottom } = useSafeAreaInsets();
   const { duration, setDuration, bottomSheetRef } =
     usePollPostComposerContext();
 
   return (
-    <Radio.Group
-      value={duration.value}
-      onChange={(value) => {
-        setDuration(
-          androidDurationOptions.find((option) => option.value === value)
-        );
-        bottomSheetRef.current?.close();
-      }}
-    >
-      {androidDurationOptions.map((option) => (
-        <Radio.Option value={option.value} accessibilityLabel={option.label}>
-          <Radio.Label>
+    <View style={{ paddingBottom: bottom + 8 }}>
+      {androidDurationOptions.map((option) => {
+        const isSelected =
+          duration.value === option.value && duration.label === option.label;
+        return (
+          <TouchableOpacity
+            key={option.label}
+            style={styles.androidDurationOption}
+            onPress={() => {
+              setDuration(option);
+              bottomSheetRef.current?.close();
+            }}
+          >
             <Typography.BodyBold style={styles.base}>
               {option.label}
             </Typography.BodyBold>
-          </Radio.Label>
-          <Radio.Icon />
-        </Radio.Option>
-      ))}
-    </Radio.Group>
+            <SvgXml
+              width={24}
+              height={24}
+              xml={isSelected ? radioChecked() : radioUnchecked()}
+              color={
+                isSelected ? theme.colors.primary : theme.colors.baseShade3
+              }
+            />
+          </TouchableOpacity>
+        );
+      })}
+    </View>
   );
 }

--- a/src/social/features/poll/Composer/components/PollDurationPicker.tsx
+++ b/src/social/features/poll/Composer/components/PollDurationPicker.tsx
@@ -1,34 +1,61 @@
-import { TouchableOpacity, View } from 'react-native';
+import { TouchableOpacity, View, useWindowDimensions } from 'react-native';
 import { SvgXml } from 'react-native-svg';
 import { useStyles } from '../styles';
 import { arrowLeft } from '../../../../../core/assets/icons';
 import { Typography } from '../../../../../core/components/Typography/Typography';
 import dayjs from 'dayjs';
-import DateTimePicker from '@react-native-community/datetimepicker';
+import DateTimePicker, {
+  DateTimePickerAndroid,
+} from '@react-native-community/datetimepicker';
 import {
   androidDurationOptions,
   usePollPostComposerContext,
 } from '../PollPostComposer';
 
 export function AndroidPollDurationPicker() {
-  const { styles, theme } = useStyles();
+  const { styles } = useStyles();
   const {
     duration,
     selectedDate,
     setSelectedTime,
     selectedTime,
     setSelectedDate,
-    setIsShowingDatePicker,
-    setIsTimePickerShown,
-    isShowingDatePicker,
-    isTimePickerShown,
   } = usePollPostComposerContext();
   const endOn = dayjs().add(duration.value, 'day');
+  const isCustom =
+    duration.label ===
+    androidDurationOptions[androidDurationOptions.length - 1].label;
+
+  const openDatePicker = () => {
+    DateTimePickerAndroid.open({
+      mode: 'date',
+      value: selectedDate,
+      minimumDate: dayjs().toDate(),
+      maximumDate: dayjs().add(1, 'month').toDate(),
+      onChange: (event, date) => {
+        if (event.type === 'set' && date) {
+          setSelectedDate(date);
+        }
+      },
+    });
+  };
+
+  const openTimePicker = () => {
+    DateTimePickerAndroid.open({
+      mode: 'time',
+      value: selectedTime,
+      is24Hour: true,
+      onChange: (event, time) => {
+        if (event.type === 'set' && time) {
+          setSelectedTime(time);
+        }
+      },
+    });
+  };
 
   return (
     <View>
-      {duration.label !==
-      androidDurationOptions[androidDurationOptions.length - 1].label ? (
+      {!isCustom ? (
         <Typography.Caption style={styles.base}>
           Ends on {endOn.format('DD MMM')} at {endOn.format('HH:mm A')}
         </Typography.Caption>
@@ -38,7 +65,7 @@ export function AndroidPollDurationPicker() {
           <View style={styles.androidDateTimeContainer}>
             <TouchableOpacity
               style={styles.androidDateTimeButton}
-              onPress={() => setIsShowingDatePicker(true)}
+              onPress={openDatePicker}
             >
               <Typography.Body style={styles.base}>
                 {dayjs(selectedDate).format('DD MMM YYYY')}
@@ -46,7 +73,7 @@ export function AndroidPollDurationPicker() {
             </TouchableOpacity>
             <TouchableOpacity
               style={styles.androidDateTimeButton}
-              onPress={() => setIsTimePickerShown(true)}
+              onPress={openTimePicker}
             >
               <Typography.Body style={styles.base}>
                 {dayjs(selectedTime).format('HH:mm A')}
@@ -55,42 +82,13 @@ export function AndroidPollDurationPicker() {
           </View>
         </View>
       )}
-      {isShowingDatePicker && (
-        <DateTimePicker
-          mode="date"
-          locale="en_US"
-          display="compact"
-          value={selectedDate}
-          minimumDate={dayjs().toDate()}
-          accentColor={theme.colors.primary}
-          maximumDate={dayjs().add(1, 'month').toDate()}
-          onChange={(event, date) => {
-            setIsShowingDatePicker(false);
-            if (event.type === 'set') {
-              setSelectedDate(date);
-            }
-          }}
-        />
-      )}
-      {isTimePickerShown && (
-        <DateTimePicker
-          mode="time"
-          display="clock"
-          value={selectedTime}
-          onChange={(event, time) => {
-            setIsTimePickerShown(false);
-            if (event.type === 'set') {
-              setSelectedTime(time);
-            }
-          }}
-        />
-      )}
     </View>
   );
 }
 
 export function IOSPollDurationPicker() {
   const { styles, theme } = useStyles();
+  const { width } = useWindowDimensions();
   const {
     setDuration,
     selectedDate,
@@ -138,7 +136,7 @@ export function IOSPollDurationPicker() {
         display="inline"
         value={selectedDate}
         minimumDate={dayjs().toDate()}
-        style={styles.iOSDateTimePicker}
+        style={[styles.iOSDateTimePicker, { width }]}
         accentColor={theme.colors.primary}
         maximumDate={dayjs().add(1, 'month').toDate()}
         onChange={(event, date) => {

--- a/src/social/features/poll/Composer/components/PollDurationPicker.tsx
+++ b/src/social/features/poll/Composer/components/PollDurationPicker.tsx
@@ -7,10 +7,7 @@ import dayjs from 'dayjs';
 import DateTimePicker, {
   DateTimePickerAndroid,
 } from '@react-native-community/datetimepicker';
-import {
-  androidDurationOptions,
-  usePollPostComposerContext,
-} from '../PollPostComposer';
+import { usePollPostComposerContext } from '../PollPostComposer';
 
 export function AndroidPollDurationPicker() {
   const { styles } = useStyles();
@@ -22,9 +19,7 @@ export function AndroidPollDurationPicker() {
     setSelectedDate,
   } = usePollPostComposerContext();
   const endOn = dayjs().add(duration.value, 'day');
-  const isCustom =
-    duration.label ===
-    androidDurationOptions[androidDurationOptions.length - 1].label;
+  const isCustom = duration.value === 0;
 
   const openDatePicker = () => {
     DateTimePickerAndroid.open({

--- a/src/social/features/poll/Composer/styles.ts
+++ b/src/social/features/poll/Composer/styles.ts
@@ -133,6 +133,13 @@ export const useStyles = () => {
     },
     iOSDateTimePicker: {
       height: 600,
+      marginLeft: 32,
+    },
+    androidDurationOption: {
+      padding: 16,
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
     },
     iOSDateTimeHeader: {
       paddingHorizontal: 16,


### PR DESCRIPTION
**Jira ticket :**
https://socialplus.atlassian.net/browse/PDT-2982

**Description :**
This pull request refactors the Android poll duration selection UI to improve reliability and user experience, especially inside the bottom sheet. It replaces the previous `Radio.Group` approach with custom `TouchableOpacity` rows and explicit SVG radio icons, and switches to using the native Android date/time picker dialogs instead of inline pickers. The iOS picker styling is also improved for better layout.

**Android Poll Duration Selection Improvements:**

* Replaced `Radio.Group` with a list of `TouchableOpacity` rows, each showing a label and a radio SVG icon, to avoid touch event issues inside the bottom sheet (`PollDurationBottomSheet.tsx`).
* Updated logic to use explicit radio icons (`radioChecked`, `radioUnchecked`) and improved accessibility by highlighting the selected option with the theme's primary color (`PollDurationBottomSheet.tsx`).
* Added new style `androidDurationOption` for better layout of duration options (`styles.ts`).

**Android Date/Time Picker Refactor:**

* Replaced inline `DateTimePicker` components with calls to `DateTimePickerAndroid.open`, showing native dialogs for date and time selection, and removed related state variables (`PollDurationPicker.tsx`). [[1]](diffhunk://#diff-419d075e97476a30780890de02a2e44ba0b427881f0d884706cfe02b29e85534L1-R58) [[2]](diffhunk://#diff-419d075e97476a30780890de02a2e44ba0b427881f0d884706cfe02b29e85534L41-R76) [[3]](diffhunk://#diff-419d075e97476a30780890de02a2e44ba0b427881f0d884706cfe02b29e85534L58-R91)

**iOS Picker Layout Enhancement:**

* The iOS date/time picker now uses the device's window width for improved appearance and adds a left margin for better alignment (`PollDurationPicker.tsx`, `styles.ts`). [[1]](diffhunk://#diff-419d075e97476a30780890de02a2e44ba0b427881f0d884706cfe02b29e85534L141-R139) [[2]](diffhunk://#diff-f3d2c59e689514f6984a453fe051fbf7386f027c0e6abd3584840f9d3d9234f9R136-R142)
**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

https://github.com/user-attachments/assets/bcb777de-3cbc-4cca-abfc-5febab1b9a34


**Note (optional) :**
