### PR TITLE
fix: PDT-3012 - visible noti livestream

### DIFF
--- a/src/social/features/community/NotificationSetting/hooks/useNotificationSetting.ts
+++ b/src/social/features/community/NotificationSetting/hooks/useNotificationSetting.ts
@@ -117,8 +117,8 @@ export function useNotificationSetting({
       },
     },
     {
-      // livestream notification setting is not supported yet in other platforms
-      visible: false,
+      // livestream notification setting is now visible
+      visible: true,
       label: 'Live streams',
       iconProps: {
         xml: livestream(),


### PR DESCRIPTION
**Jira ticket :**
https://socialplus.atlassian.net/browse/PDT-3012

**Description :**
This pull request makes a small change to the `useNotificationSetting` hook. The change updates the visibility of the livestream notification setting, making it visible to users.
**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**
n/a (need to test on sample app again)
**Note (optional) :**
