### PR TITLE
fix: PDT-3027 - scroll to top

### DIFF
--- a/src/social/features/feed/components/NewsFeed/NewsFeed.tsx
+++ b/src/social/features/feed/components/NewsFeed/NewsFeed.tsx
@@ -29,7 +29,11 @@ const AmityNewsFeedComponent: FC<AmityNewsFeedComponentType> = ({
 
   if (isExcluded) return null;
 
-  if (loading && !globalFeedPosts?.length) return <NewsFeedLoadingComponent />;
+  if (
+    (loading && !globalFeedPosts?.length) ||
+    (!itemWithAds && globalFeedPosts?.length)
+  )
+    return <NewsFeedLoadingComponent />;
 
   if (!loading && !globalFeedPosts?.length)
     return (

--- a/src/social/features/feed/components/NewsFeed/NewsFeed.tsx
+++ b/src/social/features/feed/components/NewsFeed/NewsFeed.tsx
@@ -29,8 +29,7 @@ const AmityNewsFeedComponent: FC<AmityNewsFeedComponentType> = ({
 
   if (isExcluded) return null;
 
-  if (loading || (globalFeedPosts?.length > 0 && !itemWithAds))
-    return <NewsFeedLoadingComponent />;
+  if (loading && !globalFeedPosts?.length) return <NewsFeedLoadingComponent />;
 
   if (!loading && !globalFeedPosts?.length)
     return (


### PR DESCRIPTION
**Jira ticket :**
https://socialplus.atlassian.net/browse/PDT-3027
**Description :**
This pull request makes a small adjustment to the loading logic in the `NewsFeed` component to ensure the loading indicator is only shown when appropriate. The change refines the condition for rendering the `NewsFeedLoadingComponent`, preventing it from displaying when there are already posts present.

- Updated the conditional rendering in `NewsFeed.tsx` so that `NewsFeedLoadingComponent` is only shown when loading is true and there are no posts in `globalFeedPosts`, improving the user experience by avoiding unnecessary loading indicators.
**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

https://github.com/user-attachments/assets/b1c605f6-fddf-4ee7-bf4c-b75be57c3f36


**Note (optional) :**
