### PR TITLE
fix: PDT-3071 - search user params

### DIFF
--- a/src/social/hooks/useIsCommunityModerator.ts
+++ b/src/social/hooks/useIsCommunityModerator.ts
@@ -18,7 +18,6 @@ export const useIsCommunityModerator = ({
         search: userId,
         limit: 1,
         sortBy: 'firstCreated',
-        memberships: ['member'],
       },
       async ({ error, loading, data }) => {
         if (error) return setisCommunityModerator(false);


### PR DESCRIPTION
**Jira ticket :**
https://socialplus.atlassian.net/browse/PDT-3071

**Description :**
This pull request makes a minor update to the `useIsCommunityModerator` hook. The change removes the `memberships: ['member']` filter from the query parameters, potentially broadening the search criteria for community moderators.

**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**



https://github.com/user-attachments/assets/de100b33-b77c-4ea0-a29e-4aa58b8fb4ac

**Note (optional) :**