### PR TITLE
fix: PDT-3122 - notification save toast and navigate

### DIFF
--- a/src/core/constants/index.ts
+++ b/src/core/constants/index.ts
@@ -187,6 +187,12 @@ export const TOAST = {
     },
   },
   COMMUNITY: {
+    PROFILE: {
+      UPDATE: {
+        SUCCESS: 'Successfully updated community profile.',
+        FAILED: 'Failed to save your community profile. Please try again.',
+      },
+    },
     NOTIFICATION: {
       LOAD: {
         FAILED: 'Failed to load notification settings.',

--- a/src/social/features/community/CommentsNotificationSetting/hooks/useCommentsNotificationSetting.ts
+++ b/src/social/features/community/CommentsNotificationSetting/hooks/useCommentsNotificationSetting.ts
@@ -165,11 +165,17 @@ export function useCommentsNotificationSetting({ community }: Props) {
           ),
         ],
       });
-      navigation.goBack();
+      navigation.navigate('CommunityProfilePage', {
+        communityId: community.communityId,
+      });
+      showToast({
+        type: 'success',
+        message: TOAST.COMMUNITY.PROFILE.UPDATE.SUCCESS,
+      });
     } catch {
       showToast({
         type: 'informative',
-        message: TOAST.COMMUNITY.NOTIFICATION.UPDATE.FAILED,
+        message: TOAST.COMMUNITY.PROFILE.UPDATE.FAILED,
       });
     }
   };

--- a/src/social/features/community/LivestreamsNotificationSetting/hooks/useLivestreamsNotificationSetting.ts
+++ b/src/social/features/community/LivestreamsNotificationSetting/hooks/useLivestreamsNotificationSetting.ts
@@ -106,11 +106,17 @@ export function useLivestreamsNotificationSetting({
           ),
         ],
       });
-      navigation.goBack();
+      navigation.navigate('CommunityProfilePage', {
+        communityId: community.communityId,
+      });
+      showToast({
+        type: 'success',
+        message: TOAST.COMMUNITY.PROFILE.UPDATE.SUCCESS,
+      });
     } catch {
       showToast({
         type: 'informative',
-        message: TOAST.COMMUNITY.NOTIFICATION.UPDATE.FAILED,
+        message: TOAST.COMMUNITY.PROFILE.UPDATE.FAILED,
       });
     }
   };

--- a/src/social/features/community/PostsNotificationSetting/hooks/usePostsNotificationSetting.ts
+++ b/src/social/features/community/PostsNotificationSetting/hooks/usePostsNotificationSetting.ts
@@ -137,11 +137,17 @@ export function usePostsNotificationSetting({
           ),
         ],
       });
-      navigation.goBack();
+      navigation.navigate('CommunityProfilePage', {
+        communityId: community.communityId,
+      });
+      showToast({
+        type: 'success',
+        message: TOAST.COMMUNITY.PROFILE.UPDATE.SUCCESS,
+      });
     } catch {
       showToast({
         type: 'informative',
-        message: TOAST.COMMUNITY.NOTIFICATION.UPDATE.FAILED,
+        message: TOAST.COMMUNITY.PROFILE.UPDATE.FAILED,
       });
     }
   };

--- a/src/social/features/community/StoriesNotificationSetting/hooks/useStoriesNotificationSetting.ts
+++ b/src/social/features/community/StoriesNotificationSetting/hooks/useStoriesNotificationSetting.ts
@@ -168,11 +168,17 @@ export function useStoriesNotificationSetting({
           ),
         ],
       });
-      navigation.goBack();
+      navigation.navigate('CommunityProfilePage', {
+        communityId: community.communityId,
+      });
+      showToast({
+        type: 'success',
+        message: TOAST.COMMUNITY.PROFILE.UPDATE.SUCCESS,
+      });
     } catch {
       showToast({
         type: 'informative',
-        message: TOAST.COMMUNITY.NOTIFICATION.UPDATE.FAILED,
+        message: TOAST.COMMUNITY.PROFILE.UPDATE.FAILED,
       });
     }
   };


### PR DESCRIPTION
**Jira ticket :**

- https://socialplus.atlassian.net/browse/PDT-3122

**Description :**

**User experience improvements:**

* After successfully updating notification settings in comments, posts, stories, or livestreams, users are now navigated to the `CommunityProfilePage` for the relevant community, and a success toast message is displayed (`useCommentsNotificationSetting.ts`, `usePostsNotificationSetting.ts`, `useStoriesNotificationSetting.ts`, `useLivestreamsNotificationSetting.ts`). 
* On failure, the error toast message now uses a more specific profile update message, improving clarity for the user (`useCommentsNotificationSetting.ts`, `usePostsNotificationSetting.ts`, `useStoriesNotificationSetting.ts`, `useLivestreamsNotificationSetting.ts`).

**Constants and messaging:**

* Added new constants under `TOAST.COMMUNITY.PROFILE.UPDATE` for success and failure messages related to updating the community profile (`src/core/constants/index.ts`).

**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

https://github.com/user-attachments/assets/c9be14b0-0917-4b45-8aa0-2f69ac8ca51f

**Note (optional) :**
