### PR TITLE
fix: PDT-3125 - admin delete post

### DIFF
--- a/src/social/components/PostMenu/index.tsx
+++ b/src/social/components/PostMenu/index.tsx
@@ -16,6 +16,8 @@ import { useUIKitDispatch } from '../../../core/stores/store';
 import MenuButton from '../../elements/MenuButton/MenuButton';
 import MenuAction from '../../elements/MenuAction/MenuAction';
 import { useBottomSheet } from '../../../core/stores/slices/bottomSheetSlice';
+import { useUser } from '../../hooks/useUser';
+import { isAdmin } from '../../utils/permissions';
 
 type PostMenuProps = {
   pageId?: PageID;
@@ -45,6 +47,9 @@ export function PostMenu({ pageId, componentId, post }: PostMenuProps) {
     communityId: targetType === 'community' && targetId,
     userId: myId,
   });
+
+  const currentUser = useUser(myId);
+  const isGlobalAdmin = isAdmin(currentUser?.roles);
 
   const childrenPost = post?.childrenPosts?.[0];
 
@@ -170,7 +175,7 @@ export function PostMenu({ pageId, componentId, post }: PostMenuProps) {
       ),
     },
     {
-      show: post?.creator?.userId === myId || isIAmModerator,
+      show: post?.creator?.userId === myId || isIAmModerator || isGlobalAdmin,
       action: (
         <MenuAction
           key="delete"


### PR DESCRIPTION
**Jira ticket :**
https://socialplus.atlassian.net/browse/PDT-3125

**Description :**
This pull request updates the `PostMenu` component to allow global admins to see and use the delete action on posts, in addition to post creators and moderators. The main changes involve checking for global admin status and updating permission logic.

**Permission logic improvements:**

* Added use of the `useUser` hook and `isAdmin` utility to determine if the current user is a global admin. [[1]](diffhunk://#diff-f88ca44c76b6d63dcae2aefa81679ff3de3b8045689683ccc0f42221049f0118R19-R20) [[2]](diffhunk://#diff-f88ca44c76b6d63dcae2aefa81679ff3de3b8045689683ccc0f42221049f0118R51-R53)
* Updated the visibility condition for the delete action to allow global admins to see and use it, not just post creators and moderators.
**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

https://github.com/user-attachments/assets/5a92b8c0-0124-4000-8a1d-bbc1971427fa


**Note (optional) :**
