### PR TITLE
fix: PDT-3023 - moderator create post in admin-only community

### DIFF
--- a/src/social/hooks/usePostPermission.ts
+++ b/src/social/hooks/usePostPermission.ts
@@ -5,6 +5,7 @@ import {
 import { useEffect, useState } from 'react';
 import { isModerator } from '../utils/permissions';
 import useAuth from '../../core/hooks/useAuth';
+import { MemberRoles } from '../../core/constants';
 
 type UsePostPermissionParams = {
   community?: Amity.Community;
@@ -20,16 +21,16 @@ export function usePostPermission({ community }: UsePostPermissionParams) {
   useEffect(() => {
     if (!community?.communityId || !client?.userId) return;
 
-    CommunityRepository.Membership.searchMembers(
+    CommunityRepository.Membership.getMembers(
       {
         communityId: community.communityId,
-        search: client.userId,
-        limit: 1,
-        memberships: ['member'],
-        includeDeleted: false,
+        limit: 20,
+        roles: [MemberRoles.ADMIN, MemberRoles.COMMUNITY_MODERATOR],
       },
       ({ data }) => {
-        const userRoles = data[0]?.roles ?? [];
+        const userRoles = data.find(
+          (member) => member.userId === client.userId
+        )?.roles;
         setHasPostPermission(
           isOnlyAdminCanPost ? isModerator(userRoles) : !!community?.isJoined
         );


### PR DESCRIPTION
**Jira ticket :**

- https://socialplus.atlassian.net/browse/PDT-3023

**Description :**

**Community member fetching and role checking improvements:**

* Switched from `CommunityRepository.Membership.searchMembers` to `CommunityRepository.Membership.getMembers` to retrieve community members, allowing for more accurate role checks.
* Updated the parameters to fetch up to 20 members and filter by `ADMIN` and `COMMUNITY_MODERATOR` roles using the `MemberRoles` constant, instead of searching by user ID and limiting to 'member' roles.
* Changed the logic to find the current user's roles from the returned members array, instead of assuming the first result is the current user.

**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

https://github.com/user-attachments/assets/10baeaba-eb68-43e5-abc2-5e5f22132691

**Note (optional) :**
