### PR TITLE
fix: PDT-3042 - hide notification setting when admin disable

### DIFF
--- a/src/social/features/community/Setting/Setting.tsx
+++ b/src/social/features/community/Setting/Setting.tsx
@@ -35,6 +35,7 @@ const CommunitySetting = ({ community }: CommunitySettingProps) => {
     handleCommunityStorySetting,
     handleCommunityNotificationSetting,
     isNotificationEnabled,
+    isNetworkNotificationsEnabled,
   } = useCommunitySetting(community);
 
   return (
@@ -79,17 +80,21 @@ const CommunitySetting = ({ community }: CommunitySettingProps) => {
             <View style={styles.divider} />
           </>
         )}
-        <View style={styles.titleContainer}>
-          <Title>Your preferences</Title>
-        </View>
-        <Action
-          description={isNotificationEnabled ? 'On' : 'Off'}
-          iconProps={{ xml: bell() }}
-          elementId={ElementID.notifications}
-          pageId={PageID.community_setting_page}
-          onPress={handleCommunityNotificationSetting}
-        />
-        <View style={styles.divider} />
+        {isNetworkNotificationsEnabled && (
+          <>
+            <View style={styles.titleContainer}>
+              <Title>Your preferences</Title>
+            </View>
+            <Action
+              description={isNotificationEnabled ? 'On' : 'Off'}
+              iconProps={{ xml: bell() }}
+              elementId={ElementID.notifications}
+              pageId={PageID.community_setting_page}
+              onPress={handleCommunityNotificationSetting}
+            />
+            <View style={styles.divider} />
+          </>
+        )}
         {community?.isJoined && (
           <>
             <LeaveCommunity

--- a/src/social/features/community/Setting/hooks/useCommunitySetting.ts
+++ b/src/social/features/community/Setting/hooks/useCommunitySetting.ts
@@ -136,6 +136,11 @@ export function useCommunitySetting(community: Amity.Community) {
     navigation.navigate('CommunityStorySetting', { community });
   };
 
+  const isNetworkNotificationsEnabled =
+    !notificationSettings ||
+    notificationSettings.events.length === 0 ||
+    notificationSettings.events.some((e) => e.isNetworkEnabled !== false);
+
   const handleCommunityNotificationSetting = () => {
     if (AmityCommunitySettingPageBehavior.goToNotificationPage) {
       return AmityCommunitySettingPageBehavior.goToNotificationPage({
@@ -155,5 +160,6 @@ export function useCommunitySetting(community: Amity.Community) {
     handleCommunityStorySetting,
     handleCommunityNotificationSetting,
     isNotificationEnabled: notificationSettings?.isEnabled ?? false,
+    isNetworkNotificationsEnabled,
   };
 }


### PR DESCRIPTION
**Jira ticket :**

- https://socialplus.atlassian.net/browse/PDT-3042

**Description :**

Enhancements to notification preferences display:

* Added a new `isNetworkNotificationsEnabled` computed property in `useCommunitySetting` to determine if network notifications are enabled, based on the current notification settings.
* Updated `CommunitySetting` component in `Setting.tsx` to only render the "Your preferences" section and notification controls when `isNetworkNotificationsEnabled` is true.
* Passed the new `isNetworkNotificationsEnabled` property from the `useCommunitySetting` hook to the `CommunitySetting` component for conditional rendering.

**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

<img width="952" height="870" alt="Screenshot 2026-05-29 at 11 49 06 AM" src="https://github.com/user-attachments/assets/851dffa4-cd8b-41a6-b5a3-fe17a64c8fe1" />

**Note (optional) :**
