### PR TITLE
fix: PDT-2811 - add gradient

### DIFF
--- a/src/social/features/story/View/components/AmityViewStoryItem.tsx
+++ b/src/social/features/story/View/components/AmityViewStoryItem.tsx
@@ -11,6 +11,7 @@ import {
   TouchableWithoutFeedback,
   View,
 } from 'react-native';
+import LinearGradient from 'react-native-linear-gradient';
 import { FC, memo, useCallback, useRef, useState } from 'react';
 import { useConfigImageUri, useStory } from '../../../../hooks';
 import { useStyles } from '../styles';
@@ -358,29 +359,43 @@ const AmityViewStoryItem: FC<IAmityViewStoryItem> = ({
               muted={muted}
             />
           ) : currentStory?.dataType === 'image' ? (
-            <Image
-              onLoadStart={() => setLoad(true)}
-              onLoadEnd={() => start()}
-              source={{
-                uri:
-                  currentStory?.imageData?.fileUrl ||
-                  (typeof currentStory?.data?.fileData === 'string'
-                    ? currentStory?.data?.fileData
-                    : ''),
-              }}
-              style={[
-                styles.image,
-                // eslint-disable-next-line react-native/no-inline-styles
-                isFailedImageUpload && {
-                  opacity: 0.6,
-                },
-              ]}
-              resizeMode={
-                currentStory?.data?.imageDisplayMode === 'fill'
-                  ? 'cover'
-                  : 'contain'
-              }
-            />
+            <>
+              <Image
+                onLoadStart={() => setLoad(true)}
+                onLoadEnd={() => start()}
+                source={{
+                  uri:
+                    currentStory?.imageData?.fileUrl ||
+                    (typeof currentStory?.data?.fileData === 'string'
+                      ? currentStory?.data?.fileData
+                      : ''),
+                }}
+                style={[
+                  styles.image,
+                  // eslint-disable-next-line react-native/no-inline-styles
+                  isFailedImageUpload && {
+                    opacity: 0.6,
+                  },
+                ]}
+                resizeMode={
+                  currentStory?.data?.imageDisplayMode === 'fill'
+                    ? 'cover'
+                    : 'contain'
+                }
+              />
+              {currentStory?.data?.imageDisplayMode === 'fill' && (
+                <LinearGradient
+                  colors={[
+                    'rgba(0, 0, 0, 0.4)',
+                    'transparent',
+                    'rgba(0, 0, 0, 0.4)',
+                  ]}
+                  start={{ x: 0, y: 0 }}
+                  end={{ x: 0, y: 1 }}
+                  style={styles.storyGradient}
+                />
+              )}
+            </>
           ) : null}
           {load && (
             <View style={styles.spinnerContainer}>

--- a/src/social/features/story/View/styles.ts
+++ b/src/social/features/story/View/styles.ts
@@ -244,6 +244,13 @@ export const useStyles = () => {
     errorText: {
       color: 'white',
     },
+    storyGradient: {
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      width: width,
+      height: width * (16 / 9),
+    },
   });
 
   return styles;


### PR DESCRIPTION
**Jira ticket :**
https://socialplus.atlassian.net/browse/PDT-2811

**Description :**
This pull request enhances the display of image stories by adding a gradient overlay when the image's display mode is set to "fill". This improves visual clarity and ensures that content remains readable over images. The main changes are as follows:

**UI Enhancements for Image Stories:**

* Added a `LinearGradient` overlay to image stories with `imageDisplayMode === 'fill'`, providing a subtle dark-to-transparent gradient at the top and bottom of the image for better readability.
* Wrapped the `Image` component and the conditional gradient overlay in a React fragment to support rendering both together.

**Styling Updates:**

* Introduced a new `storyGradient` style in `styles.ts` to position and size the gradient overlay appropriately over the image.

**Dependency Addition:**

* Imported `LinearGradient` from `react-native-linear-gradient` to enable the gradient overlay functionality.
**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**
N/A (Need to recheck on sample app again)
**Note (optional) :**
