### PR TITLE
fix: PDT-2786 - missing comment brand badge

### DIFF
--- a/src/social/features/comment/components/PostComment/CommentListItem/CommentListItem.tsx
+++ b/src/social/features/comment/components/PostComment/CommentListItem/CommentListItem.tsx
@@ -184,6 +184,7 @@ const CommentListItem = ({
             displayName: userObject.data.displayName,
             avatarFileId: userObject.data.avatarFileId,
             avatarCustomUrl: userObject.data?.avatarCustomUrl,
+            isBrand: userObject.data?.isBrand,
           };
 
           return {

--- a/src/social/features/comment/components/PostComment/CommentListItem/styles.ts
+++ b/src/social/features/comment/components/PostComment/CommentListItem/styles.ts
@@ -28,6 +28,7 @@ export const useStyles = () => {
       fontWeight: '600',
       fontSize: 15,
       color: theme.colors.base,
+      flexShrink: 1,
     },
     headerTextTime: {
       fontSize: 13,
@@ -52,6 +53,7 @@ export const useStyles = () => {
       borderRadius: 12,
       borderTopLeftRadius: 0,
       alignSelf: 'flex-start',
+      maxWidth: '100%',
     },
 
     viewMoreReplyBtn: {

--- a/src/social/features/comment/components/PostComment/PostComment.tsx
+++ b/src/social/features/comment/components/PostComment/PostComment.tsx
@@ -106,6 +106,7 @@ const AmityPostCommentComponent: FC<AmityPostCommentComponentType> = ({
         displayName: item.creator?.displayName,
         avatarFileId: item.creator?.avatarFileId,
         avatarCustomUrl: item.creator?.avatarCustomUrl,
+        isBrand: item.creator?.isBrand,
       };
 
       return {

--- a/src/social/features/comment/components/PostComment/ReplyCommentList/styles.ts
+++ b/src/social/features/comment/components/PostComment/ReplyCommentList/styles.ts
@@ -31,6 +31,7 @@ export const useStyles = () => {
       fontSize: 15,
       color: theme.colors.base,
       marginBottom: 4,
+      flexShrink: 1,
     },
     headerTextTime: {
       fontSize: 13,
@@ -61,6 +62,7 @@ export const useStyles = () => {
       borderRadius: 12,
       borderTopLeftRadius: 0,
       alignSelf: 'flex-start',
+      maxWidth: '100%',
     },
 
     viewMoreReplyBtn: {

--- a/src/social/features/post/components/Content/Content.tsx
+++ b/src/social/features/post/components/Content/Content.tsx
@@ -214,7 +214,9 @@ const AmityPostContentComponent: FC<AmityPostContentComponentProps> = ({
               <View style={styles.headerRow}>
                 <TouchableOpacity
                   style={
-                    targetType === 'community' ? styles.headerTextContainer : {}
+                    targetType === 'community'
+                      ? styles.headerTextContainer
+                      : styles.headerTextContainerUser
                   }
                   onPress={handleDisplayNamePress}
                 >

--- a/src/social/features/post/components/Content/styles.ts
+++ b/src/social/features/post/components/Content/styles.ts
@@ -28,6 +28,9 @@ export const useStyles = (theme: MyMD3Theme) => {
     headerTextContainer: {
       maxWidth: '60%',
     },
+    headerTextContainerUser: {
+      flexShrink: 1,
+    },
     headerText: {
       color: theme.colors.base,
     },


### PR DESCRIPTION
**Jira ticket :**
https://socialplus.atlassian.net/browse/PDT-2786

**Description :**
This pull request makes several improvements to the display and data handling of user and comment components, focusing on supporting brand users and enhancing layout flexibility. The most important changes include adding an `isBrand` property to user objects, updating styles to better handle text and container sizing, and refining how user containers are styled based on context.

**Support for brand users:**
* Added the `isBrand` property to user objects in both `CommentListItem` and `AmityPostCommentComponent` to enable special handling or display for brand accounts. [[1]](diffhunk://#diff-62a7218f42b7b98742546262a4c5c5c5ccf1dafa0085abcafce703e75124e819R187) [[2]](diffhunk://#diff-bdcc287a5998be62256b7fac65f0d0f8652eeb356956b186f413705a88a065e5R109)

**Styling improvements for text and containers:**
* Added `flexShrink: 1` to comment and reply header text styles to prevent text overflow and improve responsiveness. [[1]](diffhunk://#diff-f3a77df8c814c39cc6d956ede4696fe1530b21a718be360a66c640cb43ad1de9R31) [[2]](diffhunk://#diff-aa7ba23e6dc6d0da542d47160a7b2cd946d5c56ffc046fcafee67811e65bce68R34)
* Set `maxWidth: '100%'` for comment and reply containers to ensure they do not exceed the available space, improving layout consistency. [[1]](diffhunk://#diff-f3a77df8c814c39cc6d956ede4696fe1530b21a718be360a66c640cb43ad1de9R56) [[2]](diffhunk://#diff-aa7ba23e6dc6d0da542d47160a7b2cd946d5c56ffc046fcafee67811e65bce68R65)

**User container styling in post content:**
* Updated the `AmityPostContentComponent` to use a new `headerTextContainerUser` style for non-community users, and added this style with `flexShrink: 1` to allow user containers to shrink as needed. [[1]](diffhunk://#diff-6734d2a480656558eb30342d7d6bca9e92d1b6a43840b0ec2f86cca507d9b703L217-R219) [[2]](diffhunk://#diff-135e2643a50b8b8557202fb6926e5051acd30577808a3209a62af13086a3eccfR31-R33)
**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

https://github.com/user-attachments/assets/1690ed1b-382f-457d-92a3-4c8a32b7b7aa


**Note (optional) :**
