### PR TITLE
fix: PDT-3067 - post menu missing delete for moderator and share for public commuity

### DIFF
--- a/src/social/components/PostMenu/index.tsx
+++ b/src/social/components/PostMenu/index.tsx
@@ -18,6 +18,9 @@ import MenuAction from '../../elements/MenuAction/MenuAction';
 import { useBottomSheet } from '../../../core/stores/slices/bottomSheetSlice';
 import { useUser } from '../../hooks/useUser';
 import { isAdmin } from '../../utils/permissions';
+import { usePostShareAction } from '../../features/post/components/EngagementActions/Components/usePostShareAction';
+import { CopyLinkAction } from '../../elements/CopyLinkAction';
+import { ShareAction } from '../../elements/ShareAction';
 
 type PostMenuProps = {
   pageId?: PageID;
@@ -50,6 +53,8 @@ export function PostMenu({ pageId, componentId, post }: PostMenuProps) {
 
   const currentUser = useUser(myId);
   const isGlobalAdmin = isAdmin(currentUser?.roles);
+
+  const { shareLink } = usePostShareAction({ postId, postData: post, pageId });
 
   const childrenPost = post?.childrenPosts?.[0];
 
@@ -171,6 +176,30 @@ export function PostMenu({ pageId, componentId, post }: PostMenuProps) {
             closeBottomSheet();
             closePoll((childrenPost as Amity.Post<'poll'>)?.data?.pollId);
           }}
+        />
+      ),
+    },
+    {
+      show: !!shareLink,
+      action: (
+        <CopyLinkAction
+          key="copy-link"
+          link={shareLink}
+          pageId={pageId}
+          componentId={componentId}
+          onPress={closeBottomSheet}
+        />
+      ),
+    },
+    {
+      show: !!shareLink,
+      action: (
+        <ShareAction
+          key="share"
+          link={shareLink}
+          pageId={pageId}
+          componentId={componentId}
+          onPress={closeBottomSheet}
         />
       ),
     },

--- a/src/social/hooks/useIsCommunityModerator.ts
+++ b/src/social/hooks/useIsCommunityModerator.ts
@@ -1,6 +1,7 @@
 import { CommunityRepository } from '@amityco/ts-sdk-react-native';
 import { isModerator } from '../../core/utils/permission';
 import { useEffect, useState } from 'react';
+import { MemberRoles } from '../../core/constants';
 
 export const useIsCommunityModerator = ({
   userId,
@@ -12,23 +13,21 @@ export const useIsCommunityModerator = ({
   const [isCommunityModerator, setisCommunityModerator] = useState(false);
   useEffect(() => {
     if (!userId || !communityId) return setisCommunityModerator(false);
-    const unsub = CommunityRepository.Membership.searchMembers(
+    const unsub = CommunityRepository.Membership.getMembers(
       {
-        communityId: communityId,
-        search: userId,
-        limit: 1,
-        sortBy: 'firstCreated',
+        communityId,
+        limit: 20,
+        roles: [MemberRoles.ADMIN, MemberRoles.COMMUNITY_MODERATOR],
       },
-      async ({ error, loading, data }) => {
+      ({ error, loading, data }) => {
         if (error) return setisCommunityModerator(false);
         if (!loading) {
-          const userRoles = data[0]?.roles ?? [];
-          return setisCommunityModerator(() => isModerator(userRoles));
+          const userRoles = data.find((m) => m.userId === userId)?.roles;
+          setisCommunityModerator(isModerator(userRoles));
         }
-        return setisCommunityModerator(false);
       }
     );
     return () => unsub();
   }, [communityId, userId]);
-  return { isCommunityModerator: isCommunityModerator };
+  return { isCommunityModerator };
 };


### PR DESCRIPTION
**Jira ticket :**

- https://socialplus.atlassian.net/browse/PDT-3067

**Description :**

**Post Sharing Enhancements:**
* Added `CopyLinkAction` and `ShareAction` components to the `PostMenu`, allowing users to copy the post link or share it directly if a shareable link is available. This uses the new `usePostShareAction` hook to generate the share link. 

**Community Moderator Check Improvements:**
* Updated the `useIsCommunityModerator` hook to use `CommunityRepository.Membership.getMembers` instead of `searchMembers`, filtering by admin and moderator roles, and ensuring the check is performed against the correct user. This should make the moderator status more accurate and efficient.

**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

https://github.com/user-attachments/assets/21cb31a8-2c17-4bf2-9502-d73126997ec0

**Note (optional) :**
