### PR TITLE
fix: PDT-3048 - add category button full width on android

### DIFF
--- a/src/social/components/Button/Button.tsx
+++ b/src/social/components/Button/Button.tsx
@@ -72,14 +72,16 @@ export const Button = ({
 
     if (size === 'small') {
       return (
-        <Typography.CaptionBold style={textStyles}>
+        <Typography.CaptionBold numberOfLines={1} style={textStyles}>
           {children}
         </Typography.CaptionBold>
       );
     }
 
     return (
-      <Typography.BodyBold style={textStyles}>{children}</Typography.BodyBold>
+      <Typography.BodyBold numberOfLines={1} style={textStyles}>
+        {children}
+      </Typography.BodyBold>
     );
   };
 

--- a/src/social/features/community/AddCategory/AddCategory.tsx
+++ b/src/social/features/community/AddCategory/AddCategory.tsx
@@ -113,6 +113,7 @@ const AddCategory = () => {
       />
       <View style={styles.submitButtonContainer}>
         <ActionButton
+          fullWidth
           label="Add category"
           onPress={handleSubmit(onSubmit)}
           disabled={!isDirty || !isValid || isSubmitting}


### PR DESCRIPTION
**Jira ticket :**

- https://socialplus.atlassian.net/browse/PDT-3048

**Description :**

**UI improvements:**

* Updated `Button` component to truncate text to a single line by adding `numberOfLines={1}` to both `Typography.CaptionBold` and `Typography.BodyBold` elements.
* Set the "Add category" `ActionButton` to `fullWidth` in the `AddCategory` feature, making the button span the entire width of its container.

**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

<img width="1110" height="874" alt="Screenshot 2026-05-29 at 3 28 25 PM" src="https://github.com/user-attachments/assets/ca2014a3-0648-4938-9e4e-8cbfc99a85fa" />

**Note (optional) :**
