### PR TITLE
fix: PDT-2984 - see more chip displays not full chip

### DIFF
--- a/src/social/features/feed/components/Categories/Categories.tsx
+++ b/src/social/features/feed/components/Categories/Categories.tsx
@@ -65,7 +65,12 @@ const AmityCommunityCategoriesComponent: FC<
               <Typography.BodyBold style={styles.seeMoreCategoryText}>
                 {'See more'}
               </Typography.BodyBold>
-              <SvgXml xml={arrowRight()} />
+              <SvgXml
+                width={20}
+                height={20}
+                xml={arrowRight()}
+                color={themeStyles.colors.base}
+              />
             </View>
           </Pressable>
         ) : null


### PR DESCRIPTION
**Jira ticket :**

- https://socialplus.atlassian.net/browse/PDT-2984

**Description :**

**UI Improvements:**

* The `SvgXml` arrow icon now has explicit `width` and `height` set to `20`, and its color is set to match the theme's base color. (`[src/social/features/feed/components/Categories/Categories.tsxL68-R73](diffhunk://#diff-7c155d472622e228254a84985e33d0b1ebefcb4c4525e197fc2260a4d5576b38L68-R73)`)

**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

<img width="1054" height="868" alt="Screenshot 2026-05-29 at 3 51 06 PM" src="https://github.com/user-attachments/assets/083d2c25-8ba9-4b97-81db-e8efb4411240" />

**Note (optional) :**

