### PR TITLE
fix: PDT-2981 - hide create button for non-member of community

### DIFF
--- a/src/social/screens/CommunityProfile/index.tsx
+++ b/src/social/screens/CommunityProfile/index.tsx
@@ -359,7 +359,8 @@ function CommunityProfileActions({ pageId, communityId, styles }) {
     });
   };
 
-  if (!hasPostPermission && !hasStoryPermission) return null;
+  if (!community?.isJoined || (!hasPostPermission && !hasStoryPermission))
+    return null;
 
   return (
     <Fragment>


### PR DESCRIPTION
**Jira ticket :**

- https://socialplus.atlassian.net/browse/PDT-2981

**Description :**

- Updated the conditional rendering logic so that action buttons are only shown to users who have joined the community and have the appropriate permissions.

**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

<img width="921" height="832" alt="Screenshot 2026-05-29 at 4 34 34 PM" src="https://github.com/user-attachments/assets/406da336-375f-4089-82a5-d175f7c4cb12" />

**Note (optional) :**
