### PR TITLE
fix: PDT-2985 - too many users mentioned alert on post composer

### DIFF
--- a/src/core/constants/index.ts
+++ b/src/core/constants/index.ts
@@ -249,4 +249,10 @@ export const ALERT = {
       ACTION: 'Leave',
     },
   },
+  MENTION: {
+    TOO_MANY: {
+      TITLE: 'Too many users mentioned',
+      MESSAGE: 'You can only mention up to %s users per post.',
+    },
+  },
 } as const;

--- a/src/social/features/post/Composer/PostComposer.tsx
+++ b/src/social/features/post/Composer/PostComposer.tsx
@@ -59,7 +59,11 @@ import { PostRepository, UserRepository } from '@amityco/ts-sdk-react-native';
 import { useFile } from '../../../hooks';
 import useMention from '../../../hooks/useMention';
 import { getPostErrorMessage } from '../../../utils/errors';
-import { MAXIMUM_POST_CHARACTERS } from '../../../../core/constants';
+import {
+  ALERT,
+  MAX_MENTION_USERS,
+  MAXIMUM_POST_CHARACTERS,
+} from '../../../../core/constants';
 import { replaceTriggerValues } from 'react-native-controlled-mentions';
 import { useUIKitDispatch } from '../../../../core/stores/store';
 import { useBehaviour } from '../../../providers/BehaviourProvider';
@@ -136,6 +140,14 @@ const AmityPostComposerPage: FC<AmityPostComposerPageType> = ({
     },
     setMentionPosition: (position: IMentionPosition) => {
       setMentionsPosition((prev) => [...prev, position]);
+    },
+    isMentionLimitReached: mentionUsers.length >= MAX_MENTION_USERS,
+    onMentionLimitReached: () => {
+      Alert.alert(
+        ALERT.MENTION.TOO_MANY.TITLE,
+        ALERT.MENTION.TOO_MANY.MESSAGE.replace('%s', String(MAX_MENTION_USERS)),
+        [{ text: ALERT.ACTION.OK }]
+      );
     },
   });
 

--- a/src/social/hooks/useMention/index.tsx
+++ b/src/social/hooks/useMention/index.tsx
@@ -18,6 +18,8 @@ type UseMentionProps = {
   onChange: (value: string) => void;
   setMentionPosition: (position: IMentionPosition) => void;
   setMentionUsers: (user: TSearchItem) => void;
+  isMentionLimitReached?: boolean;
+  onMentionLimitReached?: () => void;
 };
 
 type RenderSuggestionsProps = {
@@ -32,6 +34,8 @@ function useMention({
   communityId,
   setMentionUsers,
   setMentionPosition,
+  isMentionLimitReached,
+  onMentionLimitReached,
 }: UseMentionProps) {
   const { styles } = useStyles();
   const [cursorIndex, setCursorIndex] = useState(0);
@@ -70,6 +74,8 @@ function useMention({
         communityId={communityId}
         setMentionUsers={setMentionUsers}
         setMentionPosition={setMentionPosition}
+        isMentionLimitReached={isMentionLimitReached}
+        onMentionLimitReached={onMentionLimitReached}
       />
     );
   };
@@ -89,6 +95,8 @@ type SuggestionsProps = {
   communityId?: string;
   setMentionUsers: (user: TSearchItem) => void;
   setMentionPosition: (position: IMentionPosition) => void;
+  isMentionLimitReached?: boolean;
+  onMentionLimitReached?: () => void;
 };
 
 const Suggestions = ({
@@ -100,6 +108,8 @@ const Suggestions = ({
   communityId,
   setMentionUsers,
   setMentionPosition,
+  isMentionLimitReached,
+  onMentionLimitReached,
 }: SuggestionsProps) => {
   const { styles } = useStyles();
 
@@ -145,6 +155,10 @@ const Suggestions = ({
             target={item}
             userProfileNavigateEnabled={false}
             onPress={() => {
+              if (isMentionLimitReached) {
+                onMentionLimitReached?.();
+                return;
+              }
               triggers?.mention?.onSelect(item);
               onSelectUserMention(item);
             }}


### PR DESCRIPTION
**Jira ticket :** https://socialplus.atlassian.net/browse/PDT-2985

**Description :**

When a user tried to add a 31st @mention on the Create Post page, no popup appeared and the partial \`@text\` got left in the input even though the mention was silently rejected.

Fix:

- Added \`ALERT.MENTION.TOO_MANY\` constant (title + \`%s\`-templated message) in \`src/core/constants/index.ts\` so the strings are centralized.
- Added optional \`isMentionLimitReached\` / \`onMentionLimitReached\` props to the shared \`useMention\` hook. When the limit is reached, the suggestion-item tap short-circuits **before** \`triggers.mention.onSelect\` runs, so no text is inserted into the input.
- Wired \`PostComposer\` to pass \`mentionUsers.length >= MAX_MENTION_USERS\` and the Alert callback.

**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

https://github.com/user-attachments/assets/3ba25b9f-537e-4055-b671-b1c76ec4ce31

**Note (optional) :**