### PR TITLE
fix: PDT-2810 - story avatar size

### DIFF
--- a/src/social/components/MyStories/StoryCircleItem.tsx
+++ b/src/social/components/MyStories/StoryCircleItem.tsx
@@ -84,8 +84,8 @@ const StoryCircleItem: FC<IStoryCircleItem> = ({
       />
       <SvgXml
         style={styles.storyRing}
-        width={48}
-        height={48}
+        width={64}
+        height={64}
         xml={storyRing(storyRingColor[0], storyRingColor[1])}
       />
       {hasStoryPermission && storyTarget?.failedStoriesCount > 0 ? (

--- a/src/social/components/MyStories/styles.ts
+++ b/src/social/components/MyStories/styles.ts
@@ -93,15 +93,15 @@ export const useStyles = () => {
       paddingVertical: 4,
     },
     communityAvatar: {
-      width: 40,
-      height: 40,
+      width: 56,
+      height: 56,
       borderRadius: 56,
       margin: 4,
     },
     avatarContainer: {
       alignItems: 'center',
       width: 48,
-      marginHorizontal: 8,
+      marginHorizontal: 16,
     },
   });
 


### PR DESCRIPTION
**Jira ticket :**
https://socialplus.atlassian.net/browse/PDT-2810

**Description :**
This pull request updates the visual appearance of story circles and avatars in the MyStories component to make them larger and improve spacing. The main changes involve increasing the sizes of the story ring and avatar, as well as adjusting margins for better layout.

**UI and Styling Updates:**

* Increased the size of the story ring SVG in `StoryCircleItem.tsx` from 48x48 to 64x64 for a more prominent display.
* Increased the `communityAvatar` size in `styles.ts` from 40x40 to 56x56, and adjusted the border radius accordingly for a consistent circular appearance.
* Increased horizontal margin in `avatarContainer` from 8 to 16 for improved spacing between avatars.


**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

https://github.com/user-attachments/assets/14c09b26-0e8e-4eae-8a83-d63c00b1ed77


**Note (optional) :**
