### PR TITLE
fix: PDT-3067 - scope post menu share options to non-members

### DIFF
--- a/src/social/components/PostMenu/index.tsx
+++ b/src/social/components/PostMenu/index.tsx
@@ -180,7 +180,8 @@ export function PostMenu({ pageId, componentId, post }: PostMenuProps) {
       ),
     },
     {
-      show: !!shareLink,
+      show:
+        !!shareLink && targetType === 'community' && !communityData?.isJoined,
       action: (
         <CopyLinkAction
           key="copy-link"
@@ -192,7 +193,8 @@ export function PostMenu({ pageId, componentId, post }: PostMenuProps) {
       ),
     },
     {
-      show: !!shareLink,
+      show:
+        !!shareLink && targetType === 'community' && !communityData?.isJoined,
       action: (
         <ShareAction
           key="share"


### PR DESCRIPTION
**Jira ticket :** https://socialplus.atlassian.net/browse/PDT-3067

**Description :**

Follow-up to the earlier PDT-3067 fix. The previous change showed Copy Link + Share To in the post \`…\` menu whenever \`shareLink\` was truthy — i.e. for everyone — which duplicated the engagement-bar share icon for members, moderators, and post owners.

Per the corrected spec: share options should live in the \`…\` menu **only when the engagement bar can't surface them**, which is the case for non-members of a community (the engagement bar shows "Join community to interact" instead).

- Narrowed the \`show\` condition on Copy Link + Share To from \`!!shareLink\` to \`!!shareLink && targetType === 'community' && !communityData?.isJoined\`.
- User posts (\`targetType === 'user'\`) also short-circuit to false — engagement bar handles share there.

**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

https://github.com/user-attachments/assets/3ef758b5-78c0-48e7-82c7-a9b1d1b4d436

**Note (optional) :**