### PR TITLE
fix: PDT-3244 - avatar tap navigates to user profile

### DIFF
--- a/src/social/features/community/Membership/components/MemberItem/MemberItem.tsx
+++ b/src/social/features/community/Membership/components/MemberItem/MemberItem.tsx
@@ -195,6 +195,7 @@ function MemberItem({ member, communityId, refreshMembers }: MemberItemProps) {
     <View style={styles.container}>
       <TouchableOpacity style={styles.userContainer} onPress={goToUserProfile}>
         <Avatar.User
+          shouldRedirectToUserProfile
           imageStyle={styles.userAvatar}
           uri={member.user?.avatarCustomUrl}
           roles={member.roles}

--- a/src/social/features/user/Relationship/components/UserItem/UserItem.tsx
+++ b/src/social/features/user/Relationship/components/UserItem/UserItem.tsx
@@ -36,6 +36,7 @@ export function UserItem({ profileId, userId }: UserItemProps) {
       onPress={goToUserProfile}
     >
       <Avatar.User
+        shouldRedirectToUserProfile
         userId={user?.userId}
         imageStyle={styles.avatar}
         userName={user?.displayName}


### PR DESCRIPTION
**Jira ticket :** https://socialplus.atlassian.net/browse/PDT-3244

**Description :**

Tapping a user's avatar on Followers / Following / Members / Moderators lists silently consumed the touch but never navigated to that user's profile. The shared \`Avatar\` component wraps its image in a \`TouchableOpacity\` that calls \`handlePress\`, but \`handlePress\` only navigates when \`viewable\` or \`shouldRedirectToUserProfile\` is passed. Without either flag, the inner touchable swallows the gesture and the parent row's \`goToUserProfile\` never fires.

- Added \`shouldRedirectToUserProfile\` to \`<Avatar.User>\` in \`UserItem\` (Followers + Following).
- Added \`shouldRedirectToUserProfile\` to \`<Avatar.User>\` in \`MemberItem\` (Members + Moderators).

**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

https://github.com/user-attachments/assets/aa213c1c-956b-49c2-9c3b-ee000a48fdb9

**Note (optional) :**