### PR TITLE
fix: PDT-2983 - android video story crash from oversized camera capture

### DIFF
--- a/src/social/features/story/Create/Create.tsx
+++ b/src/social/features/story/Create/Create.tsx
@@ -96,8 +96,6 @@ const AmityCreateStoryPage: FC<ICreateStoryPage> = ({
     android: useCameraFormat(activeCamera, [
       { photoAspectRatio: 16 / 9 },
       { videoAspectRatio: 16 / 9 },
-      { videoResolution: 'max' },
-      { photoResolution: 'max' },
     ]),
   });
   const activeSwitchColor = { backgroundColor: '#ffffff' };


### PR DESCRIPTION
**Jira ticket :** https://socialplus.atlassian.net/browse/PDT-2983

**Description :**

Recording a video story with the in-app camera and tapping **Share story** still crashed on Android (Samsung S25 Ultra, Android 16) after the earlier FormData-spread fix (PR #312). Gallery-picked videos uploaded fine — only camera-recorded videos crashed.

Root cause: the Android branch of \`useCameraFormat\` in \`Create.tsx\` requested \`videoResolution: 'max'\`, which resolves to 8K on flagship Androids. A 5-second 8K recording produces a 150–250 MB file; when the multipart FormData upload reads it into memory, Android kills the app (OOM / native abort). iOS doesn't trip this because its branch omits the \`max\` resolution hint and vision-camera picks a sane default (~1080p).

- Removed \`videoResolution: 'max'\` and \`photoResolution: 'max'\` from the Android camera format spec in \`src/social/features/story/Create/Create.tsx\`.
- Android branch now mirrors iOS — just the 16:9 aspect-ratio constraints. Vision-camera lands around 1080p–1440p, comfortably within Android's per-process memory budget for upload.

**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

**Note (optional) :**