### PR TITLE
fix: PDT-2982 - android poll duration tap not working

### DIFF
--- a/src/social/features/poll/Composer/PollPostComposer.tsx
+++ b/src/social/features/poll/Composer/PollPostComposer.tsx
@@ -375,6 +375,7 @@ const PollPostComposer = () => {
         ref={bottomSheetRef}
         style={styles.bottomSheet}
         height={(Platform.OS === 'ios' && isShowingDatePicker && 600) || 400}
+        disableBodyPanning={Platform.OS === 'android'}
       >
         {Platform.OS === 'android' && <AndroidBottomSheet />}
         {Platform.OS === 'ios' && <IOSBottomSheet />}


### PR DESCRIPTION
**Jira ticket :** https://socialplus.atlassian.net/browse/PDT-2982

**Description :**

Tapping a duration option in the poll-creation duration bottom sheet did nothing on Android — the selection never changed. iOS worked fine.

The \`<BottomSheet>\` from \`@devvie/bottom-sheet\` wraps its body in a \`PanResponder\`-controlled \`Animated.View\`. On Android that PanResponder claims gestures before the inner \`TouchableOpacity\` rows can respond, so \`onPress\` never fires. Pressable and TouchableOpacity both lose the gesture race, which is why the previous \`Pressable\` → \`TouchableOpacity\` swap didn't help.

- Set \`disableBodyPanning={Platform.OS === 'android'}\` on the \`<BottomSheet>\` in \`PollPostComposer.tsx\` so Android body taps reach the duration row Touchables. iOS behavior is unchanged.
- Users can still dismiss the sheet via the drag handle (separate \`disableDragHandlePanning\` prop, default false) or by tapping the backdrop.

**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

**Note (optional) :**