### PR TITLE
fix: PDT-3327 - show toast instead of join modal when visitor reacts on story

### DIFF
--- a/src/social/features/post/components/EngagementActions/Components/DetailStyle.tsx
+++ b/src/social/features/post/components/EngagementActions/Components/DetailStyle.tsx
@@ -10,7 +10,7 @@ import { AmityPostEngagementActionsSubComponentType } from './type';
 import { useStyles } from './styles';
 import {
   useAmityComponent,
-  useCommunityEngagementBehavior,
+  useInteractionBehavior,
 } from '../../../../../hooks';
 import { PageID, ComponentID } from '../../../../../enums';
 import { SvgXml } from 'react-native-svg';
@@ -37,7 +37,7 @@ const DetailStyle: FC<AmityPostEngagementActionsSubComponentType> = ({
     componentId: ComponentID.post_content,
   });
   const styles = useStyles(themeStyles);
-  const { handleCommunityEngagement } = useCommunityEngagementBehavior();
+  const { handleInteraction } = useInteractionBehavior();
   const [postData, setPostData] = useState<Amity.Post>(null);
 
   const { shareLink, handleSharePress } = usePostShareAction({
@@ -100,19 +100,19 @@ const DetailStyle: FC<AmityPostEngagementActionsSubComponentType> = ({
   }, [isLike, postId]);
 
   const onPressReaction = useCallback(() => {
-    handleCommunityEngagement({
+    handleInteraction({
       defaultBehavior: addReactionToPost,
       isJoined: community ? community.isJoined : true,
     });
-  }, [addReactionToPost, handleCommunityEngagement, community]);
+  }, [addReactionToPost, handleInteraction, community]);
 
   const onClickReactions = useCallback(() => {
-    handleCommunityEngagement({
+    handleInteraction({
       defaultBehavior: () => setIsReactionListVisible(true),
       allowNonMember: true,
       isJoined: community?.isJoined,
     });
-  }, [handleCommunityEngagement, community]);
+  }, [handleInteraction, community]);
 
   return (
     <>

--- a/src/social/features/post/components/EngagementActions/Components/FeedStyle.tsx
+++ b/src/social/features/post/components/EngagementActions/Components/FeedStyle.tsx
@@ -10,7 +10,7 @@ import {
 import { useStyles } from './styles';
 import {
   useAmityComponent,
-  useCommunityEngagementBehavior,
+  useInteractionBehavior,
 } from '../../../../../hooks';
 import { PageID, ComponentID } from '../../../../../enums';
 import { SvgXml } from 'react-native-svg';
@@ -41,7 +41,7 @@ const FeedStyle: FC<AmityPostEngagementActionsSubComponentType> = ({
   });
   const styles = useStyles(themeStyles);
   const { AmityGlobalFeedComponentBehavior } = useBehaviour();
-  const { handleCommunityEngagement } = useCommunityEngagementBehavior();
+  const { handleInteraction } = useInteractionBehavior();
   const navigation =
     useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   const [postData, setPostData] = useState<Amity.Post>(null);
@@ -86,11 +86,11 @@ const FeedStyle: FC<AmityPostEngagementActionsSubComponentType> = ({
   }, [isLike, postData, postId]);
 
   const onPressReaction = useCallback(() => {
-    handleCommunityEngagement({
+    handleInteraction({
       defaultBehavior: addReactionToPost,
       isJoined: community ? community.isJoined : true,
     });
-  }, [addReactionToPost, handleCommunityEngagement, community]);
+  }, [addReactionToPost, handleInteraction, community]);
 
   const goToPostDetail = useCallback(() => {
     if (AmityGlobalFeedComponentBehavior.goToPostDetailPage) {
@@ -102,11 +102,11 @@ const FeedStyle: FC<AmityPostEngagementActionsSubComponentType> = ({
   }, [AmityGlobalFeedComponentBehavior, navigation, postId]);
 
   const onPressComment = useCallback(() => {
-    handleCommunityEngagement({
+    handleInteraction({
       defaultBehavior: goToPostDetail,
       isJoined: community ? community.isJoined : true,
     });
-  }, [goToPostDetail, handleCommunityEngagement, community]);
+  }, [goToPostDetail, handleInteraction, community]);
 
   return (
     <Pressable onPress={onPressComment} style={styles.actionSection}>

--- a/src/social/features/story/View/components/AmityViewStoryItem.tsx
+++ b/src/social/features/story/View/components/AmityViewStoryItem.tsx
@@ -13,7 +13,11 @@ import {
 } from 'react-native';
 import LinearGradient from 'react-native-linear-gradient';
 import { FC, memo, useCallback, useRef, useState } from 'react';
-import { useConfigImageUri, useStory } from '../../../../hooks';
+import {
+  useConfigImageUri,
+  useInteractionBehavior,
+  useStory,
+} from '../../../../hooks';
 import { useStyles } from '../styles';
 import Video, { OnLoadData } from 'react-native-video';
 import {
@@ -40,6 +44,7 @@ import GestureRecognizer from 'react-native-swipe-gestures';
 import uiSlice from '../../../../../core/stores/slices/uiSlice';
 import { LoadingOverlay } from '../../../../components/legacy/LoadingOverlay';
 import Toast from '../../../../components/legacy/Toast/Toast';
+import GlobalToast from '../../../../components/Toast';
 import { Typography } from '../../../../../core/components/Typography/Typography';
 import { useTheme } from 'react-native-paper';
 import { MyMD3Theme } from '../../../../../core/providers/AmityUIKitProvider';
@@ -87,6 +92,7 @@ const AmityViewStoryItem: FC<IAmityViewStoryItem> = ({
   const progress = useRef(new Animated.Value(0)).current;
   const sheetRef = useRef<BottomSheetMethods>(null);
   const { handleReaction } = useStory();
+  const { handleInteraction } = useInteractionBehavior();
   const currentStory = storyData[current];
   const storyHyperLink = currentStory?.items[0]?.data || undefined;
   const timeDifference = useTimeDifference(currentStory?.createdAt, true);
@@ -204,33 +210,24 @@ const AmityViewStoryItem: FC<IAmityViewStoryItem> = ({
   }, [progress]);
 
   const onPressReaction = useCallback(() => {
-    if (communityData?.isJoined) {
-      handleReaction({
-        targetId: currentStory?.storyId,
-        reactionName: 'like',
-        isLiked,
-      });
-      setTotalReaction((prev) => (isLiked ? prev - 1 : prev + 1));
-      setIsLiked((prev) => !prev);
-      return;
-    }
-    progress.stopAnimation(() => setPressed(true));
-    Alert.alert('Join community to interact with all stories', null, [
-      {
-        text: 'OK',
-        onPress: () => {
-          startAnimation();
-          setPressed(false);
-        },
+    handleInteraction({
+      defaultBehavior: () => {
+        handleReaction({
+          targetId: currentStory?.storyId,
+          reactionName: 'like',
+          isLiked,
+        });
+        setTotalReaction((prev) => (isLiked ? prev - 1 : prev + 1));
+        setIsLiked((prev) => !prev);
       },
-    ]);
+      isJoined: communityData?.isJoined,
+    });
   }, [
     communityData?.isJoined,
     currentStory?.storyId,
+    handleInteraction,
     handleReaction,
     isLiked,
-    progress,
-    startAnimation,
   ]);
 
   const onCloseBottomSheet = useCallback(() => {
@@ -675,6 +672,7 @@ const AmityViewStoryItem: FC<IAmityViewStoryItem> = ({
       </BottomSheet>
       <LoadingOverlay isLoading={loading} />
       <Toast />
+      <GlobalToast />
     </View>
   );
 };

--- a/src/social/hooks/index.ts
+++ b/src/social/hooks/index.ts
@@ -36,4 +36,4 @@ export * from './useRoomSubscription';
 export * from './queries/useFlagPost';
 export * from './queries/useClosePoll';
 export * from './useGlobalBehavior';
-export * from './useCommunityEngagementBehavior';
+export * from './useInteractionBehavior';

--- a/src/social/hooks/useInteractionBehavior.ts
+++ b/src/social/hooks/useInteractionBehavior.ts
@@ -7,23 +7,23 @@ import {
   VISITOR_TOAST_DURATION,
 } from '../../core/constants';
 
-type HandleCommunityEngagementParams = {
+type HandleInteractionParams = {
   defaultBehavior?: () => void;
   allowNonMember?: boolean;
   isJoined?: boolean;
 };
 
-export const useCommunityEngagementBehavior = () => {
+export const useInteractionBehavior = () => {
   const { showToast } = useToast();
   const { AmityGlobalBehaviour } = useBehaviour();
   const { handleGlobalBehavior, isVisitorOrBot } = useGlobalBehavior();
 
-  const handleCommunityEngagement = useCallback(
+  const handleInteraction = useCallback(
     ({
       defaultBehavior,
       allowNonMember,
       isJoined,
-    }: HandleCommunityEngagementParams) => {
+    }: HandleInteractionParams) => {
       handleGlobalBehavior({
         defaultBehavior: () => {
           if (allowNonMember || isJoined) {
@@ -43,5 +43,5 @@ export const useCommunityEngagementBehavior = () => {
     [handleGlobalBehavior, AmityGlobalBehaviour, showToast]
   );
 
-  return { handleCommunityEngagement, isVisitorOrBot };
+  return { handleInteraction, isVisitorOrBot };
 };


### PR DESCRIPTION
**Jira ticket :** https://socialplus.atlassian.net/browse/PDT-3327

**Description :**

When a visitor tapped a reaction on a story, the app showed a blocking "Join community to interact with all stories" alert instead of the visitor toast. The story reaction handler gated only on `isJoined` and fired a native `Alert` for every non-joined user.

- Route the story `onPressReaction` through the shared `useInteractionBehavior` gate: visitor → "Create an account or sign in to continue." toast; signed-in non-member → "Join community to interact." toast; member → like as before. Removes the `Alert` modal.
- Mount the global `Toast` inside the story viewer so the toast renders above the story (the story is a native `coverScreen` modal, so a root-level toast is otherwise hidden behind it; z-index cannot cross the native-modal boundary).
- Renamed `useCommunityEngagementBehavior` → `useInteractionBehavior` (`handleInteraction`) since it now gates posts and stories.

**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

<img width="1344" height="2992" alt="Screenshot_1781769958" src="https://github.com/user-attachments/assets/31360f1f-6b10-4b2f-a55b-df6ed4d007bd" />

**Note (optional) :**