### PR TITLE
fix: PDT-3325 - show sign-in toast when visitor taps community member count

### DIFF
--- a/src/social/screens/CommunityProfile/components/Header/Header.tsx
+++ b/src/social/screens/CommunityProfile/components/Header/Header.tsx
@@ -6,6 +6,7 @@ import {
   useCommunity,
   isModerator,
   useUser,
+  useGlobalBehavior,
 } from '../../../../hooks';
 import { useStyles } from './styles';
 import { CommunityCover } from '../../elements/CommunityCover/CommunityCover';
@@ -50,6 +51,7 @@ const AmityCommunityHeaderComponent: FC<AmityCommunityHeaderComponentProps> = ({
   const client = Client.getActiveClient();
   const navigation =
     useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+  const { handleGlobalBehavior } = useGlobalBehavior();
   const componentId = ComponentID.community_header;
   const { community } = useCommunity(communityId);
   const { posts: pendingPosts } = usePosts({
@@ -153,8 +155,12 @@ const AmityCommunityHeaderComponent: FC<AmityCommunityHeaderComponentProps> = ({
             community={community}
             style={styles.infoWrap}
             onPress={() => {
-              navigation.navigate('CommunityMembership', {
-                community: community,
+              handleGlobalBehavior({
+                defaultBehavior: () => {
+                  navigation.navigate('CommunityMembership', {
+                    community: community,
+                  });
+                },
               });
             }}
           />


### PR DESCRIPTION
**Jira ticket :** https://socialplus.atlassian.net/browse/PDT-3325

**Description :**

A visitor tapping the member count on a community profile was navigated straight to the Member List page. The member-count handler called `navigation.navigate('CommunityMembership', ...)` with no visitor gate.

- Wrap the `CommunityInfo` `onPress` in the community header with `handleGlobalBehavior` (`useGlobalBehavior`): visitor → "Create an account or sign in to continue." toast and stays on the page; signed-in users (member or not) → open the Member List as before.

**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

<img width="1344" height="2992" alt="Screenshot_1781772751" src="https://github.com/user-attachments/assets/55e61422-3cb4-4efc-8a41-7b96ff9289ae" />

**Note (optional) :**