### PR TITLE
fix: PDT-3328 - show action controls on story comments

### DIFF
--- a/src/social/components/Social/CommentListItem/CommentListItem.tsx
+++ b/src/social/components/Social/CommentListItem/CommentListItem.tsx
@@ -44,7 +44,7 @@ import ReplyCommentList from '../../legacy/Social/ReplyCommentList';
 import AmityReactionListComponent from '../../../features/reaction/components/List';
 import { CommentRepository } from '@amityco/ts-sdk-react-native';
 import { useTimeDifference } from '../../../hooks/useTimeDifference';
-import { useGlobalBehavior } from '../../../hooks/useGlobalBehavior';
+import { useInteractionBehavior } from '../../../hooks/useInteractionBehavior';
 import { LinkPreview } from '../../PreviewLink';
 import { Typography } from '../../../../core/components/Typography/Typography';
 import { pen, report, trash, unreport } from '../../../../core/assets/icons';
@@ -291,13 +291,19 @@ const CommentListItem = ({
     onClickReply && onClickReply(user, commentId);
   };
 
-  const { handleGlobalBehavior, isVisitorOrBot } = useGlobalBehavior();
+  const { handleInteraction, isVisitorOrBot } = useInteractionBehavior();
 
   const onPressLike = () =>
-    handleGlobalBehavior({ defaultBehavior: addReactionToComment });
+    handleInteraction({
+      defaultBehavior: addReactionToComment,
+      isJoined: !disabledInteraction,
+    });
 
   const onPressReply = () =>
-    handleGlobalBehavior({ defaultBehavior: onHandleReply });
+    handleInteraction({
+      defaultBehavior: onHandleReply,
+      isJoined: !disabledInteraction,
+    });
 
   const onPressCommentReaction = () => {
     setIsReactionListVisible(true);
@@ -343,59 +349,57 @@ const CommentListItem = ({
               />
             )}
           </View>
-          {!disabledInteraction && (
-            <View style={styles.actionSection}>
-              <View style={styles.rowContainer}>
-                <View style={styles.timeRow}>
+          <View style={styles.actionSection}>
+            <View style={styles.rowContainer}>
+              <View style={styles.timeRow}>
+                <Typography.Caption style={styles.headerTextTime}>
+                  {timeDifference}
+                </Typography.Caption>
+                {(editedAt !== createdAt || isEditComment) && (
                   <Typography.Caption style={styles.headerTextTime}>
-                    {timeDifference}
+                    {' '}
+                    (edited)
                   </Typography.Caption>
-                  {(editedAt !== createdAt || isEditComment) && (
-                    <Typography.Caption style={styles.headerTextTime}>
-                      {' '}
-                      (edited)
-                    </Typography.Caption>
-                  )}
-                </View>
-                <TouchableOpacity onPress={onPressLike} style={styles.likeBtn}>
-                  <Typography.CaptionBold
-                    style={isLike ? styles.likedText : styles.btnText}
-                  >
-                    Like
-                  </Typography.CaptionBold>
-                </TouchableOpacity>
-                <TouchableOpacity
-                  onPress={disabledComment ? undefined : onPressReply}
-                  style={styles.likeBtn}
-                >
-                  <Typography.CaptionBold style={styles.btnText}>
-                    Reply
-                  </Typography.CaptionBold>
-                </TouchableOpacity>
-                {!isVisitorOrBot && (
-                  <TouchableOpacity onPress={openModal}>
-                    <SvgXml
-                      xml={threeDots(theme.colors.baseShade2)}
-                      width="20"
-                      height="20"
-                    />
-                  </TouchableOpacity>
                 )}
               </View>
-
-              {likeReaction > 0 && (
-                <TouchableOpacity
-                  onPress={onPressCommentReaction}
-                  style={styles.likeBtn}
+              <TouchableOpacity onPress={onPressLike} style={styles.likeBtn}>
+                <Typography.CaptionBold
+                  style={isLike ? styles.likedText : styles.btnText}
                 >
-                  <Typography.Caption style={styles.btnText}>
-                    {likeReaction}
-                  </Typography.Caption>
-                  <SvgXml xml={likeCircle} width="20" height="20" />
+                  Like
+                </Typography.CaptionBold>
+              </TouchableOpacity>
+              <TouchableOpacity
+                onPress={disabledComment ? undefined : onPressReply}
+                style={styles.likeBtn}
+              >
+                <Typography.CaptionBold style={styles.btnText}>
+                  Reply
+                </Typography.CaptionBold>
+              </TouchableOpacity>
+              {!isVisitorOrBot && (
+                <TouchableOpacity onPress={openModal}>
+                  <SvgXml
+                    xml={threeDots(theme.colors.baseShade2)}
+                    width="20"
+                    height="20"
+                  />
                 </TouchableOpacity>
               )}
             </View>
-          )}
+
+            {likeReaction > 0 && (
+              <TouchableOpacity
+                onPress={onPressCommentReaction}
+                style={styles.likeBtn}
+              >
+                <Typography.Caption style={styles.btnText}>
+                  {likeReaction}
+                </Typography.Caption>
+                <SvgXml xml={likeCircle} width="20" height="20" />
+              </TouchableOpacity>
+            )}
+          </View>
 
           {previewReplyCommentList.length > 0 && !isOpenReply && (
             <ReplyCommentList

--- a/src/social/features/story/View/components/AmityViewStoryItem.tsx
+++ b/src/social/features/story/View/components/AmityViewStoryItem.tsx
@@ -649,6 +649,7 @@ const AmityViewStoryItem: FC<IAmityViewStoryItem> = ({
               withAvatar={true}
             />
           </KeyboardAvoidingView>
+          <GlobalToast />
         </Modal>
       )}
       <BottomSheet


### PR DESCRIPTION
**Jira ticket :** https://socialplus.atlassian.net/browse/PDT-3328

**Description :**

On story comments, the action controls (Timestamp, Like, Reply, 3-dot) were hidden for visitors and non-members — the whole action row was wrapped in `{!disabledInteraction && ...}` and the story passes `disabledInteraction={!isJoined}`. The controls should be visible; the actions are gated instead.

- `CommentListItem`: removed the `!disabledInteraction` wrapper so the action row always renders; routed Like/Reply through `useInteractionBehavior` (`isJoined: !disabledInteraction`) so visitor → "Create an account or sign in to continue.", signed-in non-member → "Join community to interact.", member → action. 3-dot stays hidden for visitors (its items need an account); visible for signed-in users.
- `AmityViewStoryItem`: mounted `<GlobalToast />` inside the comment-sheet modal so the gate toast is visible above the sheet (the comment sheet is a separate `coverScreen` modal).

**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

<img width="709" height="824" alt="Screenshot 2026-06-18 at 4 55 13 PM" src="https://github.com/user-attachments/assets/9ea9c338-2057-4f9c-8bae-c611bac09f81" />

<img width="805" height="853" alt="Screenshot 2026-06-18 at 4 55 41 PM" src="https://github.com/user-attachments/assets/f9af45cc-085a-4b23-9c70-9cc9cfb3215e" />

**Note (optional) :**