### PR TITLE
fix: PDT-3352 - let visitor tap poll vote and show sign-in toast

### DIFF
--- a/src/social/components/PollContent/PollOption.tsx
+++ b/src/social/components/PollContent/PollOption.tsx
@@ -9,6 +9,7 @@ import Button, { BUTTON_SIZE } from '../Button/Button';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../../../core/routes/RouteParamList';
+import { useInteractionBehavior } from '../../hooks/useInteractionBehavior';
 
 type PollOptionsProps = {
   post?: Amity.Post<any>;
@@ -42,10 +43,10 @@ export function PollOptions({
     useNavigation<NativeStackNavigationProp<RootStackParamList>>();
 
   const { styles } = useStyles();
+  const { handleInteraction } = useInteractionBehavior();
   const [selectedOption, setSelectedOption] = useState<Amity.PollAnswer[]>([]);
 
   const btnDisabled = selectedOption.length === 0;
-  const optionDisabled = !!disabledPoll;
 
   return (
     <View>
@@ -60,7 +61,6 @@ export function PollOptions({
         <Radio.Group<Amity.PollAnswer>
           value={selectedOption[0]}
           style={styles.optionGroup}
-          disabled={optionDisabled}
           onChange={(value) => setSelectedOption([value])}
           select={(value, option) => value.id === option.id}
         >
@@ -79,11 +79,7 @@ export function PollOptions({
                 ]}
               >
                 <Radio.Label style={styles.optionLabel}>
-                  <Typography.BodyBold
-                    style={[optionDisabled && styles.optionLabelDisabled]}
-                  >
-                    {option.data}
-                  </Typography.BodyBold>
+                  <Typography.BodyBold>{option.data}</Typography.BodyBold>
                 </Radio.Label>
                 <Radio.Icon />
               </Radio.Option>
@@ -93,7 +89,6 @@ export function PollOptions({
         <CheckBox.Group<Amity.PollAnswer>
           value={selectedOption}
           style={styles.optionGroup}
-          disabled={optionDisabled}
           onChange={(value) => setSelectedOption(value)}
           select={(value, option) =>
             !!value.find((item) => item.id === option.id)
@@ -115,11 +110,7 @@ export function PollOptions({
                 ]}
               >
                 <CheckBox.Label style={styles.optionLabel}>
-                  <Typography.BodyBold
-                    style={[optionDisabled && styles.optionLabelDisabled]}
-                  >
-                    {option.data}
-                  </Typography.BodyBold>
+                  <Typography.BodyBold>{option.data}</Typography.BodyBold>
                 </CheckBox.Label>
                 <CheckBox.Icon />
               </CheckBox.Option>
@@ -144,12 +135,15 @@ export function PollOptions({
       )}
       {!isPollClosed && !isAlreadyVoted && (
         <TouchableOpacity
-          disabled={btnDisabled || optionDisabled}
-          style={[
-            styles.voteBtn,
-            (btnDisabled || optionDisabled) && styles.voteBtnDisabled,
-          ]}
-          onPress={() => votePoll(selectedOption.map((option) => option.id))}
+          disabled={btnDisabled}
+          style={[styles.voteBtn, btnDisabled && styles.voteBtnDisabled]}
+          onPress={() =>
+            handleInteraction({
+              defaultBehavior: () =>
+                votePoll(selectedOption.map((option) => option.id)),
+              isJoined: !disabledPoll,
+            })
+          }
         >
           <Typography.BodyBold style={styles.voteBtnLabel}>
             Vote


### PR DESCRIPTION
**Jira ticket :** https://socialplus.atlassian.net/browse/PDT-3352

**Description :**

Poll vote options and the Vote button were hard-disabled for visitors/non-members (`optionDisabled = !!disabledPoll`, where `disabledPoll = isPublic && !isJoined`), so a visitor couldn't even tap to vote. The poll should stay interactive and the submit should be gated.

- `PollOption`: removed the `disabledPoll`-based disabling so options + Vote stay tappable; routed the Vote submit through `useInteractionBehavior` (`isJoined: !disabledPoll`) → visitor → "Create an account or sign in to continue.", signed-in non-member → "Join community to interact.", member → vote. No vote is submitted for gated users; results stay unchanged.

**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

<img width="773" height="825" alt="Screenshot 2026-06-19 at 10 31 38 AM" src="https://github.com/user-attachments/assets/a70e666d-2b53-4183-a089-0523b1dd6080" />

<img width="888" height="883" alt="Screenshot 2026-06-19 at 10 32 08 AM" src="https://github.com/user-attachments/assets/34edd675-bbe6-419f-bc50-9d17dd99972f" />

**Note (optional) :**