### PR TITLE
fix: PDT-3355 - show sign-in toast when visitor taps follower/following count

### DIFF
--- a/src/social/features/user/Profile/components/Header/hooks/useHeader.ts
+++ b/src/social/features/user/Profile/components/Header/hooks/useHeader.ts
@@ -112,24 +112,28 @@ export function useHeader(user?: Amity.User) {
 
   const navigateToRelationship = (tab: UserRelationshipTab) => {
     if (!user?.userId) return;
-    if (!isMyProfile && isPrivateNetwork && !isFollowing) {
-      showToast({
-        type: 'informative',
-        message: TOAST.USER.RELATIONSHIP.FOLLOW_TO_INTERACT,
-      });
-      return;
-    }
-    if (AmityUserProfileHeaderComponentBehavior?.goToUserRelationshipPage) {
-      AmityUserProfileHeaderComponentBehavior.goToUserRelationshipPage({
-        userId: user.userId,
-        selectedTab: tab,
-      });
-    } else {
-      navigation.push('UserRelationship', {
-        userId: user.userId,
-        selectedTab: tab,
-      });
-    }
+    handleGlobalBehavior({
+      defaultBehavior: () => {
+        if (!isMyProfile && isPrivateNetwork && !isFollowing) {
+          showToast({
+            type: 'informative',
+            message: TOAST.USER.RELATIONSHIP.FOLLOW_TO_INTERACT,
+          });
+          return;
+        }
+        if (AmityUserProfileHeaderComponentBehavior?.goToUserRelationshipPage) {
+          AmityUserProfileHeaderComponentBehavior.goToUserRelationshipPage({
+            userId: user.userId,
+            selectedTab: tab,
+          });
+        } else {
+          navigation.push('UserRelationship', {
+            userId: user.userId,
+            selectedTab: tab,
+          });
+        }
+      },
+    });
   };
 
   return {


### PR DESCRIPTION
**Jira ticket :** https://socialplus.atlassian.net/browse/PDT-3355

**Description :**

A visitor tapping the Follower/Following count on a public user profile was navigated to the relationship list (showing an empty state) instead of being prompted to sign in. `navigateToRelationship` only gated the private-network non-follower case, so visitors on public profiles fell through to navigation.

- `useHeader`: wrapped `navigateToRelationship` in `handleGlobalBehavior` (`useGlobalBehavior`) — visitor → "Create an account or sign in to continue." toast, no navigation; signed-in users → existing behavior (navigate to the list, or "Follow user to interact." for private-network non-followers).

**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

https://github.com/user-attachments/assets/63c19271-067b-4808-bb26-0f646057801e

**Note (optional) :**