### PR TITLE
fix: PDT-3356 - show post menu for visitors and sign-in toast on report

### DIFF
--- a/src/social/components/PostMenu/index.tsx
+++ b/src/social/components/PostMenu/index.tsx
@@ -3,7 +3,7 @@ import { Alert, View } from 'react-native';
 import { getCommunityById } from '../../../core/legacy/community';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { useFlagPost, isModerator } from '../../hooks';
+import { useFlagPost, isModerator, useGlobalBehavior } from '../../hooks';
 import { deletePostById } from '../../../core/legacy/feed';
 import useAuth from '../../../core/hooks/useAuth';
 import globalFeedSlice from '../../../core/stores/slices/globalfeedSlice';
@@ -30,6 +30,7 @@ type PostMenuProps = {
 
 export function PostMenu({ pageId, componentId, post }: PostMenuProps) {
   const { showToast } = useToast();
+  const { handleGlobalBehavior } = useGlobalBehavior();
   const { closePoll } = useClosePoll();
   const { client } = useAuth();
   const [communityData, setCommunityData] = useState<Amity.Community>(null);
@@ -121,7 +122,7 @@ export function PostMenu({ pageId, componentId, post }: PostMenuProps) {
           iconProps={{ xml: report() }}
           onPress={() => {
             closeBottomSheet();
-            reportPost(postId);
+            handleGlobalBehavior({ defaultBehavior: () => reportPost(postId) });
           }}
         />
       ),
@@ -136,7 +137,9 @@ export function PostMenu({ pageId, componentId, post }: PostMenuProps) {
           label={'Unreport post'}
           onPress={() => {
             closeBottomSheet();
-            unreportPost(postId);
+            handleGlobalBehavior({
+              defaultBehavior: () => unreportPost(postId),
+            });
           }}
         />
       ),

--- a/src/social/features/post/components/Content/Content.tsx
+++ b/src/social/features/post/components/Content/Content.tsx
@@ -35,7 +35,6 @@ import { PostMenu } from '../../../../components/PostMenu';
 import PinBadge from '../../../../elements/PinBadge';
 import AnnouncementBadge from '../../../../elements/AnnouncementBadge';
 import { Typography } from '../../../../../core/components/Typography/Typography';
-import useAuth from '../../../../../core/hooks/useAuth';
 
 type AmityPostContentComponentProps = {
   post: Amity.Post;
@@ -75,7 +74,6 @@ const AmityPostContentComponent: FC<AmityPostContentComponentProps> = ({
     componentId: componentId,
   });
   const styles = useStyles(themeStyles);
-  const { isVisitorOrBot } = useAuth();
   const [textPost, setTextPost] = useState<string>('');
   const [communityData, setCommunityData] = useState<Amity.Community>(null);
   const navigation =
@@ -294,11 +292,10 @@ const AmityPostContentComponent: FC<AmityPostContentComponentProps> = ({
             category === AmityPostCategory.PIN_AND_ANNOUNCEMENT) && (
             <PinBadge componentId={ComponentID.post_content} />
           )}
-          {!isVisitorOrBot &&
-            AmityPostContentComponentStyle ===
-              AmityPostContentComponentStyleEnum.feed && (
-              <PostMenu post={post} pageId={pageId} componentId={componentId} />
-            )}
+          {AmityPostContentComponentStyle ===
+            AmityPostContentComponentStyleEnum.feed && (
+            <PostMenu post={post} pageId={pageId} componentId={componentId} />
+          )}
         </Pressable>
         <View>
           <View style={styles.bodySection}>


### PR DESCRIPTION
**Jira ticket :** https://socialplus.atlassian.net/browse/PDT-3356

**Description :**

A visitor reporting a post hit the SDK call directly and got "Failed to report post. Please try again." instead of a sign-in prompt. The post `…` menu was also hidden for visitors on the feed (only reachable from the detail page).

- `PostMenu`: routed Report / Unreport through `handleGlobalBehavior` (`useGlobalBehavior`) — visitor → "Create an account or sign in to continue." toast; signed-in users → action as before.
- `Content`: removed the `!isVisitorOrBot` guard so the `…` menu shows for visitors on the feed too (Report is now gated; Copy Link/Share remain available).

**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

https://github.com/user-attachments/assets/03b662c5-0b39-4b7a-a2f6-8a8e77d8b3d6

**Note (optional) :**