### PR TITLE
fix: PDT-3353 - truncate long user profile description on iOS

### DIFF
--- a/src/social/features/user/Profile/components/Header/styles.ts
+++ b/src/social/features/user/Profile/components/Header/styles.ts
@@ -51,6 +51,8 @@ export const useStyles = (
     },
     hiddenText: {
       position: 'absolute',
+      left: 0,
+      right: 0,
       opacity: 0,
     },
     seeMore: {


### PR DESCRIPTION
**Jira ticket :** https://socialplus.atlassian.net/browse/PDT-3353

**Description :**

On the user profile, a long description wasn't truncating to 4 lines + "... see more" on iOS (showed full text). The hidden `Text` used to measure line count had `position: absolute` with no width constraint, so on iOS it sized to its intrinsic (unwrapped) width — `onTextLayout` reported too few lines and the truncation early-returned.

- `Header/styles.ts`: added `left: 0, right: 0` to `hiddenText` so the measuring text wraps at the container content width on both platforms, giving the real line count → truncation + "... see more" applies consistently.

**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

https://github.com/user-attachments/assets/5886a382-d013-4cc7-a93c-fbe34eabb7d7

**Note (optional) :**