### PR TITLE
fix: PDT-3326 - freeze livestream last frame for visitors on stream end

### DIFF
--- a/src/social/features/livestream/Player/Player.tsx
+++ b/src/social/features/livestream/Player/Player.tsx
@@ -83,7 +83,7 @@ function AmityLiveStreamPlayerPage() {
   };
   useRoomSubscription({ room });
 
-  const { client } = useAuth();
+  const { client, isVisitorOrBot } = useAuth();
   const videoRef = useRef<any>(null);
   const isStreamEnding = useRef(false);
 
@@ -127,7 +127,7 @@ function AmityLiveStreamPlayerPage() {
   }, []);
 
   useEffect(() => {
-    if (!room?.status) return;
+    if (!room?.status || isVisitorOrBot) return;
 
     const shouldEnd =
       room.status === RoomStatus.ended ||
@@ -149,13 +149,14 @@ function AmityLiveStreamPlayerPage() {
         setVideoKey((prev) => prev + 1);
       }, 50);
     }
-  }, [room?.status, wasLive]);
+  }, [room?.status, wasLive, isVisitorOrBot]);
 
   useEffect(() => {
+    if (isVisitorOrBot) return;
     if (room?.status === RoomStatus.terminated) {
       navigation.replace('LivestreamTerminated', { type: 'viewer' });
     }
-  }, [room?.status, navigation]);
+  }, [room?.status, navigation, isVisitorOrBot]);
 
   const showControlsTemporarily = useCallback(() => {
     setShowControls(true);
@@ -171,9 +172,10 @@ function AmityLiveStreamPlayerPage() {
   }, [showControlsTemporarily]);
 
   const shouldShowEndThumbnail =
-    room?.status === RoomStatus.ended ||
-    (room?.status === RoomStatus.recorded && wasLive) ||
-    (room as any)?.user?.isGlobalBan;
+    !isVisitorOrBot &&
+    (room?.status === RoomStatus.ended ||
+      (room?.status === RoomStatus.recorded && wasLive) ||
+      (room as any)?.user?.isGlobalBan);
 
   if (!room || error) {
     return (
@@ -246,6 +248,7 @@ function AmityLiveStreamPlayerPage() {
                     setIsPaused(false);
                   }
                 }}
+                onEnd={() => setIsPaused(true)}
               />
             )}
 


### PR DESCRIPTION
**Jira ticket :** https://socialplus.atlassian.net/browse/PDT-3326

**Description :**

When a livestream ended, a visitor saw a black screen instead of the last frame. The ended state is driven by `room.status` (delivered over the RTE room-watcher topic), which visitor sessions don't receive — so the player never transitioned and the mounted `<Video>` blanked when the live source stopped.

Per product decision, visitors should freeze on the last frame with no ended state:
- `Player`: added `onEnd` on the `<Video>` → `setIsPaused(true)` so the player parks on its last decoded frame when the live stream ends.
- Gated the ended UI off for visitors: `shouldShowEndThumbnail` requires `!isVisitorOrBot`, the `terminated` navigation is skipped for visitors, and the iOS dismiss-fullscreen / Android reload end-effect is skipped for visitors (those blank the frame). Signed-in viewers are unchanged (last frame → ended state).

Note: a clean stream end freezes reliably; an abrupt drop (no clean `onEnd`) may still black out — to monitor in QA.

**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

<img width="1064" height="884" alt="Screenshot 2026-06-19 at 1 55 47 PM" src="https://github.com/user-attachments/assets/7229db33-f4e8-4a61-821e-d5427a54d796" />

**Note (optional) :**