### PR TITLE
fix: PDT-3351 - show comment/reply menu for visitors with gated report

### DIFF
--- a/src/social/components/PostMenu/index.tsx
+++ b/src/social/components/PostMenu/index.tsx
@@ -3,7 +3,7 @@ import { Alert, View } from 'react-native';
 import { getCommunityById } from '../../../core/legacy/community';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { useFlagPost, isModerator } from '../../hooks';
+import { useFlagPost, isModerator, useGlobalBehavior } from '../../hooks';
 import { deletePostById } from '../../../core/legacy/feed';
 import useAuth from '../../../core/hooks/useAuth';
 import globalFeedSlice from '../../../core/stores/slices/globalfeedSlice';
@@ -30,6 +30,7 @@ type PostMenuProps = {
 
 export function PostMenu({ pageId, componentId, post }: PostMenuProps) {
   const { showToast } = useToast();
+  const { handleGlobalBehavior } = useGlobalBehavior();
   const { closePoll } = useClosePoll();
   const { client } = useAuth();
   const [communityData, setCommunityData] = useState<Amity.Community>(null);
@@ -121,7 +122,7 @@ export function PostMenu({ pageId, componentId, post }: PostMenuProps) {
           iconProps={{ xml: report() }}
           onPress={() => {
             closeBottomSheet();
-            reportPost(postId);
+            handleGlobalBehavior({ defaultBehavior: () => reportPost(postId) });
           }}
         />
       ),
@@ -136,7 +137,9 @@ export function PostMenu({ pageId, componentId, post }: PostMenuProps) {
           label={'Unreport post'}
           onPress={() => {
             closeBottomSheet();
-            unreportPost(postId);
+            handleGlobalBehavior({
+              defaultBehavior: () => unreportPost(postId),
+            });
           }}
         />
       ),

--- a/src/social/components/Social/CommentListItem/CommentListItem.tsx
+++ b/src/social/components/Social/CommentListItem/CommentListItem.tsx
@@ -291,7 +291,7 @@ const CommentListItem = ({
     onClickReply && onClickReply(user, commentId);
   };
 
-  const { handleInteraction, isVisitorOrBot } = useInteractionBehavior();
+  const { handleInteraction } = useInteractionBehavior();
 
   const onPressLike = () =>
     handleInteraction({
@@ -377,15 +377,13 @@ const CommentListItem = ({
                   Reply
                 </Typography.CaptionBold>
               </TouchableOpacity>
-              {!isVisitorOrBot && (
-                <TouchableOpacity onPress={openModal}>
-                  <SvgXml
-                    xml={threeDots(theme.colors.baseShade2)}
-                    width="20"
-                    height="20"
-                  />
-                </TouchableOpacity>
-              )}
+              <TouchableOpacity onPress={openModal}>
+                <SvgXml
+                  xml={threeDots(theme.colors.baseShade2)}
+                  width="20"
+                  height="20"
+                />
+              </TouchableOpacity>
             </View>
 
             {likeReaction > 0 && (
@@ -435,10 +433,10 @@ const CommentListItem = ({
               style={styles.viewMoreReplyBtn}
             >
               <SvgXml xml={expandIcon} />
-              <Typography.CaptionBold style={styles.viewMoreText}>
+              <Text style={styles.viewMoreText}>
                 View {childrenNumber}{' '}
                 {childrenNumber === 1 ? 'reply' : 'replies'}
-              </Typography.CaptionBold>
+              </Text>
             </TouchableOpacity>
           )}
 
@@ -448,9 +446,7 @@ const CommentListItem = ({
               style={styles.viewMoreReplyBtn}
             >
               <SvgXml xml={expandIcon} />
-              <Typography.CaptionBold style={styles.viewMoreText}>
-                View more replies
-              </Typography.CaptionBold>
+              <Text style={styles.viewMoreText}>View more replies</Text>
             </TouchableOpacity>
           )}
         </View>
@@ -504,7 +500,13 @@ const CommentListItem = ({
               </View>
             ) : (
               <TouchableOpacity
-                onPress={reportCommentObject}
+                onPress={() => {
+                  closeModal();
+                  handleInteraction({
+                    defaultBehavior: reportCommentObject,
+                    allowNonMember: true,
+                  });
+                }}
                 style={styles.modalRow}
               >
                 <SvgXml

--- a/src/social/components/Social/CommentListItem/styles.ts
+++ b/src/social/components/Social/CommentListItem/styles.ts
@@ -71,12 +71,13 @@ export const useStyles = () => {
       paddingHorizontal: 8,
       marginTop: 12,
       flexDirection: 'row',
-      justifyContent: 'center',
       alignItems: 'center',
       alignSelf: 'flex-start',
     },
     viewMoreText: {
+      fontWeight: '600',
       color: theme.colors.secondaryShade1,
+      paddingHorizontal: 4,
     },
     commentText: {
       fontSize: 15,

--- a/src/social/components/legacy/Social/ReplyCommentList/index.tsx
+++ b/src/social/components/legacy/Social/ReplyCommentList/index.tsx
@@ -157,7 +157,7 @@ export default function ReplyCommentList({
     }
   };
 
-  const { handleGlobalBehavior, isVisitorOrBot } = useGlobalBehavior();
+  const { handleGlobalBehavior } = useGlobalBehavior();
 
   const onPressLike = () =>
     handleGlobalBehavior({ defaultBehavior: addReactionToComment });
@@ -283,15 +283,13 @@ export default function ReplyCommentList({
                 </Typography.CaptionBold>
               </TouchableOpacity>
 
-              {!isVisitorOrBot && (
-                <TouchableOpacity onPress={openModal} style={styles.threeDots}>
-                  <SvgXml
-                    xml={threeDots(theme.colors.base)}
-                    width="20"
-                    height="16"
-                  />
-                </TouchableOpacity>
-              )}
+              <TouchableOpacity onPress={openModal} style={styles.threeDots}>
+                <SvgXml
+                  xml={threeDots(theme.colors.base)}
+                  width="20"
+                  height="16"
+                />
+              </TouchableOpacity>
             </View>
             {likeReaction > 0 && (
               <TouchableOpacity
@@ -366,7 +364,12 @@ export default function ReplyCommentList({
               </View>
             ) : (
               <TouchableOpacity
-                onPress={reportCommentObject}
+                onPress={() => {
+                  closeModal();
+                  handleGlobalBehavior({
+                    defaultBehavior: reportCommentObject,
+                  });
+                }}
                 style={styles.modalRow}
               >
                 <SvgXml

--- a/src/social/features/comment/components/PostComment/CommentListItem/CommentListItem.tsx
+++ b/src/social/features/comment/components/PostComment/CommentListItem/CommentListItem.tsx
@@ -315,7 +315,7 @@ const CommentListItem = ({
     onClickReply && onClickReply(user, commentId);
   };
 
-  const { handleGlobalBehavior, isVisitorOrBot } = useGlobalBehavior();
+  const { handleGlobalBehavior } = useGlobalBehavior();
 
   const onPressLike = () =>
     handleGlobalBehavior({ defaultBehavior: addReactionToComment });
@@ -415,18 +415,13 @@ const CommentListItem = ({
                 <TouchableOpacity onPress={onPressReply} style={styles.likeBtn}>
                   <Text style={styles.btnText}>Reply</Text>
                 </TouchableOpacity>
-                {!isVisitorOrBot && (
-                  <TouchableOpacity
-                    onPress={openModal}
-                    style={styles.threeDots}
-                  >
-                    <SvgXml
-                      xml={threeDots(theme.colors.base)}
-                      width="20"
-                      height="16"
-                    />
-                  </TouchableOpacity>
-                )}
+                <TouchableOpacity onPress={openModal} style={styles.threeDots}>
+                  <SvgXml
+                    xml={threeDots(theme.colors.base)}
+                    width="20"
+                    height="16"
+                  />
+                </TouchableOpacity>
               </View>
 
               {likeReaction > 0 && (
@@ -539,7 +534,12 @@ const CommentListItem = ({
               </View>
             ) : (
               <TouchableOpacity
-                onPress={reportCommentObject}
+                onPress={() => {
+                  closeModal();
+                  handleGlobalBehavior({
+                    defaultBehavior: reportCommentObject,
+                  });
+                }}
                 style={styles.modalRow}
               >
                 <SvgXml

--- a/src/social/features/comment/components/PostComment/ReplyCommentList/index.tsx
+++ b/src/social/features/comment/components/PostComment/ReplyCommentList/index.tsx
@@ -146,7 +146,7 @@ const ReplyCommentList = ({
     }
   };
 
-  const { handleGlobalBehavior, isVisitorOrBot } = useGlobalBehavior();
+  const { handleGlobalBehavior } = useGlobalBehavior();
 
   const onPressLike = () =>
     handleGlobalBehavior({ defaultBehavior: addReactionToComment });
@@ -304,15 +304,13 @@ const ReplyCommentList = ({
                   {!isLike ? 'Like' : 'Liked'}
                 </Text>
               </TouchableOpacity>
-              {!isVisitorOrBot && (
-                <TouchableOpacity onPress={openModal} style={styles.threeDots}>
-                  <SvgXml
-                    xml={threeDots(theme.colors.base)}
-                    width="20"
-                    height="16"
-                  />
-                </TouchableOpacity>
-              )}
+              <TouchableOpacity onPress={openModal} style={styles.threeDots}>
+                <SvgXml
+                  xml={threeDots(theme.colors.base)}
+                  width="20"
+                  height="16"
+                />
+              </TouchableOpacity>
             </View>
 
             {likeReaction > 0 && (
@@ -348,6 +346,7 @@ const ReplyCommentList = ({
                 styles.twoOptions,
             ]}
           >
+            <View style={styles.handleBar} />
             {user?.userId === (client as Amity.Client).userId ? (
               <View>
                 <TouchableOpacity
@@ -375,7 +374,12 @@ const ReplyCommentList = ({
               </View>
             ) : (
               <TouchableOpacity
-                onPress={reportCommentObject}
+                onPress={() => {
+                  closeModal();
+                  handleGlobalBehavior({
+                    defaultBehavior: reportCommentObject,
+                  });
+                }}
                 style={styles.modalRow}
               >
                 <SvgXml

--- a/src/social/features/comment/components/PostComment/ReplyCommentList/styles.ts
+++ b/src/social/features/comment/components/PostComment/ReplyCommentList/styles.ts
@@ -6,6 +6,14 @@ export const useStyles = () => {
   const theme = useTheme() as MyMD3Theme;
 
   const styles = StyleSheet.create({
+    handleBar: {
+      alignSelf: 'center',
+      width: 36,
+      backgroundColor: theme.colors.baseShade4,
+      height: 5,
+      marginVertical: 10,
+      borderRadius: 10,
+    },
     commentWrap: {
       backgroundColor: theme.colors.background,
       paddingHorizontal: 12,

--- a/src/social/features/post/components/Content/Content.tsx
+++ b/src/social/features/post/components/Content/Content.tsx
@@ -35,7 +35,6 @@ import { PostMenu } from '../../../../components/PostMenu';
 import PinBadge from '../../../../elements/PinBadge';
 import AnnouncementBadge from '../../../../elements/AnnouncementBadge';
 import { Typography } from '../../../../../core/components/Typography/Typography';
-import useAuth from '../../../../../core/hooks/useAuth';
 
 type AmityPostContentComponentProps = {
   post: Amity.Post;
@@ -75,7 +74,6 @@ const AmityPostContentComponent: FC<AmityPostContentComponentProps> = ({
     componentId: componentId,
   });
   const styles = useStyles(themeStyles);
-  const { isVisitorOrBot } = useAuth();
   const [textPost, setTextPost] = useState<string>('');
   const [communityData, setCommunityData] = useState<Amity.Community>(null);
   const navigation =
@@ -294,11 +292,10 @@ const AmityPostContentComponent: FC<AmityPostContentComponentProps> = ({
             category === AmityPostCategory.PIN_AND_ANNOUNCEMENT) && (
             <PinBadge componentId={ComponentID.post_content} />
           )}
-          {!isVisitorOrBot &&
-            AmityPostContentComponentStyle ===
-              AmityPostContentComponentStyleEnum.feed && (
-              <PostMenu post={post} pageId={pageId} componentId={componentId} />
-            )}
+          {AmityPostContentComponentStyle ===
+            AmityPostContentComponentStyleEnum.feed && (
+            <PostMenu post={post} pageId={pageId} componentId={componentId} />
+          )}
         </Pressable>
         <View>
           <View style={styles.bodySection}>


### PR DESCRIPTION
**Jira ticket :** https://socialplus.atlassian.net/browse/PDT-3351

**Description :**

Visitors couldn't open the comment/reply `…` menu, and the Report action wasn't gated behind the visitor sign-in prompt.

- Removed the `!isVisitorOrBot` guard on the comment & reply 3-dots across all four surfaces (post comment/reply + story comment/reply) so visitors see the menu.
- Gated **Report / Unreport** through the visitor/non-member behavior — visitor → "Create an account or sign in to continue." toast; non-members can still report; members report as before.
- Added the drag-handle bar to the post reply 3-dot modal so it matches the comment modal.
- Fixed the Android "View N replies" label: `Typography.CaptionBold`'s `lineHeight: 18` wrapped the word onto a clipped second line — swapped to a plain `<Text>`, mirroring the working post label.

**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

https://github.com/user-attachments/assets/bdd59c5c-9013-45cc-ad94-573364ac5ab0

**Note (optional) :**
