### PR TITLE
fix: PDT-3337 - hide tab navigation when explore is the only tab

### DIFF
--- a/src/social/screens/SocialHomePage/index.tsx
+++ b/src/social/screens/SocialHomePage/index.tsx
@@ -81,6 +81,10 @@ const AmitySocialHomePage = () => {
     display: activeTab === tab ? ('flex' as const) : ('none' as const),
   });
 
+  const tabNames = isVisitorOrBot
+    ? [exploreTab]
+    : [newsFeedTab, exploreTab, myCommunitiesTab, PROFILE_TAB];
+
   return (
     <SafeAreaView
       testID="social_home_page"
@@ -89,15 +93,13 @@ const AmitySocialHomePage = () => {
       style={styles.container}
     >
       <AmitySocialHomeTopNavigationComponent activeTab={activeTab} />
-      <CustomSocialTab
-        activeTab={activeTab}
-        onTabChange={onTabChange}
-        tabNames={
-          isVisitorOrBot
-            ? [exploreTab]
-            : [newsFeedTab, exploreTab, myCommunitiesTab, PROFILE_TAB]
-        }
-      />
+      {tabNames.length > 1 && (
+        <CustomSocialTab
+          activeTab={activeTab}
+          onTabChange={onTabChange}
+          tabNames={tabNames}
+        />
+      )}
       <Divider />
       {!isVisitorOrBot && (
         <View style={tabStyle(newsFeedTab)}>


### PR DESCRIPTION
**Jira ticket :** https://socialplus.atlassian.net/browse/PDT-3337

**Description :**

In Visitor mode the social home page rendered the tab navigation strip with a single `Explore` tab. The tab strip is now hidden when there is only one available tab.

- `SocialHomePage`: lifted `tabNames` into a variable and render `CustomSocialTab` only when `tabNames.length > 1`. The `Divider` is kept so the header is still separated from the Explore content.

**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

<img width="1344" height="2992" alt="Screenshot_1781867316" src="https://github.com/user-attachments/assets/865e247b-5b87-445a-87f0-41d88570fdc7" />

**Note (optional) :**