### PR TITLE
fix: PDT-3337 - hide divider when explore is the only tab

### DIFF
--- a/src/social/screens/SocialHomePage/index.tsx
+++ b/src/social/screens/SocialHomePage/index.tsx
@@ -94,13 +94,15 @@ const AmitySocialHomePage = () => {
     >
       <AmitySocialHomeTopNavigationComponent activeTab={activeTab} />
       {tabNames.length > 1 && (
-        <CustomSocialTab
-          activeTab={activeTab}
-          onTabChange={onTabChange}
-          tabNames={tabNames}
-        />
+        <>
+          <CustomSocialTab
+            activeTab={activeTab}
+            onTabChange={onTabChange}
+            tabNames={tabNames}
+          />
+          <Divider />
+        </>
       )}
-      <Divider />
       {!isVisitorOrBot && (
         <View style={tabStyle(newsFeedTab)}>
           <AmityNewsFeedComponent


### PR DESCRIPTION
**Jira ticket :** https://socialplus.atlassian.net/browse/PDT-3337

**Description :**

Follow-up to the merged tab-navigation fix (#369). When `Explore` is the only available tab (Visitor mode), the `Divider` below the tab strip is now also hidden so the top navigation sits directly above the Explore content.

- `SocialHomePage`: moved the `Divider` inside the `tabNames.length > 1` guard alongside `CustomSocialTab`.

**Check lists :**

- [x] Test code
- [x] Build local pass (optional)
- [x] Code is the same level as origin/develop branch

**Screen shot :**

<img width="1344" height="2992" alt="Screenshot_1782706956" src="https://github.com/user-attachments/assets/5352a522-7487-4a0a-80b5-8c19037e2b67" />

**Note (optional) :**