### PR TITLE
fix(chat): clear the sender's media upload spinner once the message syncs

### DIFF
--- a/src/social/features/chat/components/AmityMessageBubble/AmityMessageBubble.tsx
+++ b/src/social/features/chat/components/AmityMessageBubble/AmityMessageBubble.tsx
@@ -8,7 +8,7 @@
 // caption, and a flat 10-line clamp.
 
 // 1. React / RN imports
-import { useState, type ReactNode } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 import {
   Image,
   Linking,
@@ -137,6 +137,23 @@ type AmityMessageBubbleProps = {
   onOpenVideo?: (message: Amity.Message) => void;
   /** Local file uri shown optimistically while the media uploads. */
   localPreviewUrl?: string;
+  /**
+   * The media is still in flight. Derived from syncState by MessageRow — NOT
+   * from `localPreviewUrl`, which outlives the upload: the preview is kept as
+   * the display source after the message syncs so the bubble doesn't flash back
+   * to a spinner while the remote url warms. Gating the overlay/tap/long-press
+   * on the preview alone left the sender's own image stuck under a spinner and
+   * permanently uninteractive once it had synced.
+   */
+  isUploading?: boolean;
+  /**
+   * The remote media finished loading, so the local preview can be dropped.
+   * Web renders a hidden `<img>`/`<video>` of the remote url whose load event
+   * fires this; RN uses `Image.prefetch` for images and a hidden `<Video>` for
+   * videos (see the preloaders below) — same purpose: warm the remote source
+   * BEFORE swapping, so the bubble never flashes an empty/loading frame.
+   */
+  onMediaLoaded?: (fileId: string) => void;
   /** Cancel an in-flight upload (shown on the upload overlay). */
   onCancelUpload?: () => void;
   /** Open the full-text "see more" screen for long messages. */
@@ -183,6 +200,8 @@ export function AmityMessageBubble({
   onOpenImage,
   onOpenVideo,
   localPreviewUrl,
+  isUploading = false,
+  onMediaLoaded,
   onCancelUpload,
   onSeeMore,
   isActive = false,
@@ -200,6 +219,8 @@ export function AmityMessageBubble({
           onOpenImage={onOpenImage}
           onLongPress={onLongPress}
           localPreviewUrl={localPreviewUrl}
+          isUploading={isUploading}
+          onMediaLoaded={onMediaLoaded}
           onCancelUpload={onCancelUpload}
         />
       );
@@ -211,6 +232,8 @@ export function AmityMessageBubble({
           onOpenVideo={onOpenVideo}
           onLongPress={onLongPress}
           localPreviewUrl={localPreviewUrl}
+          isUploading={isUploading}
+          onMediaLoaded={onMediaLoaded}
           onCancelUpload={onCancelUpload}
         />
       );
@@ -422,6 +445,8 @@ type ImageBubbleProps = {
   onOpenImage?: (url: string, message: Amity.Message) => void;
   onLongPress?: (message: Amity.Message) => void;
   localPreviewUrl?: string;
+  isUploading?: boolean;
+  onMediaLoaded?: (fileId: string) => void;
   onCancelUpload?: () => void;
 };
 
@@ -431,6 +456,8 @@ function ImageBubble({
   onOpenImage,
   onLongPress,
   localPreviewUrl,
+  isUploading = false,
+  onMediaLoaded,
   onCancelUpload,
 }: ImageBubbleProps) {
   const { styles } = useStyles();
@@ -441,10 +468,36 @@ function ImageBubble({
   const [pressed, setPressed] = useState(false);
   const [hasLoadError, setHasLoadError] = useState(false);
   const [loaded, setLoaded] = useState(false);
+  const [preloaded, setPreloaded] = useState(false);
 
   const isFailed = isErrorState(message);
   const displaySrc = localPreviewUrl ?? mediumUrl;
   const openUrl = largeUrl ?? mediumUrl;
+
+  // Web renders a hidden <img src={mediumUrl} onLoad={onMediaLoaded}> next to the
+  // preview: it warms the remote image, and only once it has decoded does the
+  // pending upload (and with it the preview) get dropped, so the swap from local
+  // file → CDN url is invisible. RN's equivalent is Image.prefetch, which fills
+  // the same image cache the <Image> below reads from — no extra view needed.
+  // `preloaded` then suppresses the remote-download spinner for the swap, since
+  // changing `source` resets `loaded` even when the bitmap is already cached.
+  useEffect(() => {
+    if (!localPreviewUrl || !mediumUrl || !fileId || !onMediaLoaded)
+      return undefined;
+    let cancelled = false;
+    Image.prefetch(mediumUrl)
+      .then(() => {
+        if (cancelled) return;
+        setPreloaded(true);
+        onMediaLoaded(fileId);
+      })
+      // A prefetch failure must not strand the preview: the <Image> retries the
+      // same url on its own, so just leave the pending upload in place.
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [localPreviewUrl, mediumUrl, fileId, onMediaLoaded]);
 
   if (!displaySrc) {
     return (
@@ -466,8 +519,8 @@ function ImageBubble({
     );
   }
 
-  const showUploadOverlay = !!localPreviewUrl && !isFailed;
-  const canOpen = !!onOpenImage && !!openUrl && !isFailed && !localPreviewUrl;
+  const showUploadOverlay = isUploading && !isFailed;
+  const canOpen = !!onOpenImage && !!openUrl && !isFailed && !isUploading;
   const showFailedCaption = showsFailedCaption(isFailed);
 
   const bubble = (
@@ -479,7 +532,7 @@ function ImageBubble({
       onPressOut={() => setPressed(false)}
       onPress={canOpen ? () => onOpenImage!(openUrl!, message) : undefined}
       onLongPress={
-        isFailed || !!localPreviewUrl || !onLongPress
+        isFailed || isUploading || !onLongPress
           ? undefined
           : () => onLongPress(message)
       }
@@ -496,7 +549,7 @@ function ImageBubble({
           remote source downloads, so overlay a spinner on the media-loading surface
           until it loads. Skipped for a local preview (that path shows the upload
           overlay instead). RN-specific adaptation of web's image loading state. */}
-      {!loaded && !localPreviewUrl ? (
+      {!loaded && !localPreviewUrl && !preloaded ? (
         <View style={styles.mediaLoadingOverlay}>
           <Loader.Spinner size="lg" />
         </View>
@@ -528,6 +581,8 @@ type VideoBubbleProps = {
   onOpenVideo?: (message: Amity.Message) => void;
   onLongPress?: (message: Amity.Message) => void;
   localPreviewUrl?: string;
+  isUploading?: boolean;
+  onMediaLoaded?: (fileId: string) => void;
   onCancelUpload?: () => void;
 };
 
@@ -537,6 +592,8 @@ function VideoBubble({
   onOpenVideo,
   onLongPress,
   localPreviewUrl,
+  isUploading = false,
+  onMediaLoaded,
   onCancelUpload,
 }: VideoBubbleProps) {
   const { styles } = useStyles();
@@ -556,8 +613,8 @@ function VideoBubble({
     );
   }
 
-  const showUploadOverlay = !!localPreviewUrl && !isFailed;
-  const canOpen = !!onOpenVideo && !isFailed && !localPreviewUrl;
+  const showUploadOverlay = isUploading && !isFailed;
+  const canOpen = !!onOpenVideo && !isFailed && !isUploading;
   const showFailedCaption = showsFailedCaption(isFailed);
 
   const bubble = (
@@ -569,7 +626,7 @@ function VideoBubble({
       onPressOut={() => setPressed(false)}
       onPress={canOpen ? () => onOpenVideo!(message) : undefined}
       onLongPress={
-        isFailed || !!localPreviewUrl || !onLongPress
+        isFailed || isUploading || !onLongPress
           ? undefined
           : () => onLongPress(message)
       }
@@ -596,6 +653,24 @@ function VideoBubble({
           controls={false}
         />
       </View>
+      {/* Web's hidden preload <video src={videoUrl} onLoadedMetadata={...}>: warm
+          the remote video so the pending upload (and its preview) is only dropped
+          once the CDN source can render, otherwise the swap shows a black frame
+          while the remote stream opens. RN's <Video onLoad> is the onLoadedMetadata
+          equivalent. Mounted only in the narrow preview+remote window, and wrapped
+          in a pointerEvents="none" View for the same touch reason as above. */}
+      {localPreviewUrl && videoUrl && fileId && onMediaLoaded ? (
+        <View style={styles.mediaPreload} pointerEvents="none">
+          <Video
+            source={{ uri: videoUrl }}
+            style={styles.mediaPreload}
+            paused
+            muted
+            controls={false}
+            onLoad={() => onMediaLoaded(fileId)}
+          />
+        </View>
+      ) : null}
       {showUploadOverlay ? (
         <MediaUploadOverlay onCancel={onCancelUpload} />
       ) : (

--- a/src/social/features/chat/components/AmityMessageBubble/styles.ts
+++ b/src/social/features/chat/components/AmityMessageBubble/styles.ts
@@ -222,6 +222,15 @@ export const useStyles = () => {
       justifyContent: 'center',
       backgroundColor: token(AmityColorToken.SurfaceMediaImageLoading),
     },
+    // Web `.mediaBubble__preload` — the off-screen element that warms the remote
+    // media before the local preview is dropped. Never meant to be seen: 1×1 and
+    // fully transparent, but still mounted so the native view actually loads.
+    mediaPreload: {
+      position: 'absolute',
+      width: 1,
+      height: 1,
+      opacity: 0,
+    },
     mediaPressedScrim: {
       ...StyleSheet.absoluteFillObject,
       // Web used --asc-color-message-overlay (no RN token); substituted with the

--- a/src/social/features/chat/features/conversation/Chat.tsx
+++ b/src/social/features/chat/features/conversation/Chat.tsx
@@ -109,6 +109,7 @@ export function Chat({ channelId, userDisplayName, onBack }: ChatProps) {
           isLoadingFirstPage={c.isLoadingFirstPage}
           onSeeMore={c.openSeeMore}
           pendingUploads={c.composer.pendingUploads}
+          onMediaLoaded={c.composer.handleMediaLoaded}
           bubbleHandlers={{
             onEdit: c.handleBubbleEdit,
             onReply: c.handleBubbleReply,

--- a/src/social/features/chat/features/conversation/components/MessageList/MessageList.tsx
+++ b/src/social/features/chat/features/conversation/components/MessageList/MessageList.tsx
@@ -62,6 +62,14 @@ type MessageListProps = {
    * bubble short-circuits to the loading placeholder, hiding its failed caption.
    */
   pendingUploads?: PendingUpload[];
+  /**
+   * The remote media for a just-uploaded file has finished loading, so its local
+   * preview can be dropped (web GroupChat → MessageList → MessageBubble
+   * `onMediaLoaded`). Without it a successful upload stays in `pendingUploads`
+   * for as long as the thread is open and the bubble keeps rendering the local
+   * file uri instead of the CDN url.
+   */
+  onMediaLoaded?: (fileId: string) => void;
 };
 
 const AT_BOTTOM_THRESHOLD = 48;
@@ -102,6 +110,7 @@ export function MessageList({
   bubbleHandlers,
   viewerIsModerator = false,
   pendingUploads,
+  onMediaLoaded,
 }: MessageListProps) {
   const { styles } = useStyles();
   const previews = useMemo(
@@ -192,6 +201,7 @@ export function MessageList({
             <MessageRow
               message={message}
               localPreviewUrl={localPreviewUrl}
+              onMediaLoaded={onMediaLoaded}
               isUser={isUser}
               isGroupChat={isGroupChat}
               currentUserId={currentUserId}

--- a/src/social/features/chat/features/conversation/components/MessageRow/MessageRow.tsx
+++ b/src/social/features/chat/features/conversation/components/MessageRow/MessageRow.tsx
@@ -47,6 +47,8 @@ type MessageRowProps = {
   viewerIsModerator?: boolean;
   /** Local preview for an in-flight or failed upload (see MessageList). */
   localPreviewUrl?: string;
+  /** The remote media has loaded — the local preview can be dropped. */
+  onMediaLoaded?: (fileId: string) => void;
 };
 
 // 4. Named function component
@@ -65,6 +67,7 @@ export function MessageRow({
   bubbleHandlers,
   viewerIsModerator = false,
   localPreviewUrl,
+  onMediaLoaded,
 }: MessageRowProps) {
   const { styles } = useStyles();
   const sendingLabel = useString('amity_chat_sending_status');
@@ -78,6 +81,12 @@ export function MessageRow({
   const isSynced =
     syncState === undefined || syncState === ('synced' as Amity.SyncState);
   const isFailed = syncState === ('error' as Amity.SyncState);
+
+  // The preview outlives the upload — MessageList keeps mapping it onto the real
+  // message by fileId so the bubble doesn't flash back to a spinner while the
+  // remote url warms. So "still uploading" has to come from syncState (the same
+  // signal the Sending caption below uses), not from the preview's presence.
+  const isUploading = !!localPreviewUrl && !isSynced && !isFailed;
 
   const showSenderName = !isUser && isGroupChat && !message.parentId;
   const timeText = message.createdAt
@@ -206,6 +215,8 @@ export function MessageRow({
                   // recognised and the bubble snaps back while the menu is up.
                   isActive={isOpen}
                   localPreviewUrl={localPreviewUrl}
+                  isUploading={isUploading}
+                  onMediaLoaded={onMediaLoaded}
                   onLongPress={() => {
                     onOpenBubbleMenu?.(message);
                     openPopover();

--- a/src/social/features/chat/features/group/chat/GroupChat.tsx
+++ b/src/social/features/chat/features/group/chat/GroupChat.tsx
@@ -103,6 +103,7 @@ export function GroupChat({
           isLoadingFirstPage={c.isLoadingFirstPage}
           onSeeMore={c.openSeeMore}
           pendingUploads={c.composer.pendingUploads}
+          onMediaLoaded={c.composer.handleMediaLoaded}
           // PDT-4155 (web PR 1818): only group channels have moderators, so web
           // threads isModerator from useGroupChat and the 1:1 Chat does not.
           viewerIsModerator={c.isModerator}


### PR DESCRIPTION
Follow-up to #380 (found during QA of that branch, after it was merged).

## The bug

Sending an image or video left the **sender's own** bubble under the upload overlay forever. The recipient saw the media and the caption flipped from "Sending" to a timestamp, but the spinner never cleared — and because the same condition gated tap and long-press, the bubble stayed unopenable with no action menu for as long as the thread was open.

## Root cause

`runMediaUpload` only *sets* `fileId` on a successful upload; nothing removed the entry from `pendingUploads`. The intended cleanup, `handleMediaLoaded`, was returned from the composer but **never consumed by any caller** (dead since a7993f0a), so `MessageList`'s `byFileId` map kept resolving a `localPreviewUrl` for the real, fully-synced message — and both media bubbles used `!!localPreviewUrl` as their stand-in for "still uploading".

## The fix

- `MessageRow` derives `isUploading` from `syncState` (the signal the "Sending" caption already uses), and the bubbles gate the upload overlay, `canOpen` and `onLongPress` on that instead of on the preview's presence. `localPreviewUrl` stays the *display source*, so nothing flashes while the remote url warms.
- Wire `handleMediaLoaded` through to the bubbles, matching web's hidden preload element (`GroupChat.tsx:116` → `MessageList.tsx:326` → `MessageBubble.tsx:282`): `Image.prefetch` for images, a hidden 1×1 `<Video onLoad>` for videos, so the pending entry is dropped only once the remote source is warm. Without it the bubble rendered the local file uri for the whole visit and the entry leaked.

The syncState gate is kept as a backstop for the case where a preload never fires, so the overlay can no longer strand the bubble either way.

## QA status

- **Verified on device** (Android emulator): the stuck spinner is gone, tap opens the viewer, long-press opens the action menu.
- **Not yet exercised**: the `handleMediaLoaded` wiring landed after that run — typecheck + lint clean and the app loads without error, but nobody has sent media since. Worth watching **in-room** (leaving the thread unmounts the composer and drops `pendingUploads` regardless, so an out-of-room check proves nothing): whether the image flashes at the preview→CDN swap, and whether the video thumbnail goes black (`onLoad` firing before transcoding completes).
- **Untouched, pre-existing**: `onCancelUpload` is never supplied by `MessageRow`/`MessageList`, so the overlay's cancel control is inert; and if the upload succeeds but `createMessage` fails, the entry keeps its `fileId` and no failed bubble renders at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)